### PR TITLE
Fix TypeScript errors: add type assertions for LangChain tool args

### DIFF
--- a/src/lib/server/session-tools/canvas.ts
+++ b/src/lib/server/session-tools/canvas.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+﻿import { z } from 'zod'
 import { tool, type StructuredToolInterface } from '@langchain/core/tools'
 import { loadSessions, saveSessions } from '../storage'
 import { notify } from '../ws-hub'
@@ -80,7 +80,7 @@ const CanvasExtension: Extension = {
         },
         required: ['action']
       },
-      execute: async (args, context) => executeCanvasAction(args, { sessionId: context.session.id })
+      execute: async (args, context) => executeCanvasAction(args as Record<string, unknown>, { sessionId: context.session.id })
     }
   ]
 }
@@ -94,7 +94,7 @@ export function buildCanvasTools(bctx: ToolBuildContext): StructuredToolInterfac
   if (!bctx.hasExtension('canvas')) return []
   return [
     tool(
-      async (args) => executeCanvasAction(args, { sessionId: bctx.ctx?.sessionId || undefined }),
+      async (args) => executeCanvasAction(args as Record<string, unknown>, { sessionId: bctx.ctx?.sessionId || undefined }),
       {
         name: 'canvas',
         description: CanvasExtension.tools![0].description,

--- a/src/lib/server/session-tools/chatroom.ts
+++ b/src/lib/server/session-tools/chatroom.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+﻿import { z } from 'zod'
 import { tool, type StructuredToolInterface } from '@langchain/core/tools'
 import { loadChatrooms, saveChatrooms, loadAgents } from '../storage'
 import { genId } from '@/lib/id'
@@ -333,7 +333,7 @@ const ChatroomExtension: Extension = {
         },
         required: ['action'],
       },
-      execute: async (args, context) => executeChatroomAction(args, { agentId: context.session.agentId }),
+      execute: async (args, context) => executeChatroomAction(args as Record<string, unknown>, { agentId: context.session.agentId }),
     },
   ],
 }
@@ -347,7 +347,7 @@ export function buildChatroomTools(bctx: ToolBuildContext): StructuredToolInterf
   if (!bctx.hasExtension('manage_chatrooms')) return []
   return [
     tool(
-      async (args) => executeChatroomAction(args, { agentId: bctx.ctx?.agentId }),
+      async (args) => executeChatroomAction(args as Record<string, unknown>, { agentId: bctx.ctx?.agentId }),
       {
         name: 'manage_chatrooms',
         description: ChatroomExtension.tools![0].description,

--- a/src/lib/server/session-tools/delegate.ts
+++ b/src/lib/server/session-tools/delegate.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+﻿import { z } from 'zod'
 import { tool, type StructuredToolInterface } from '@langchain/core/tools'
 import { spawn, type ChildProcess } from 'child_process'
 import type { ToolBuildContext } from './context'
@@ -570,7 +570,7 @@ async function executeDelegateAction(args: Record<string, unknown>, bctx: Delega
   })
 }
 
-// stripEnvPrefixes removed — use buildCliEnv() from cli-utils instead
+// stripEnvPrefixes removed â€” use buildCliEnv() from cli-utils instead
 
 function parseCodexOutputText(ev: Record<string, unknown>): string | null {
   if (ev.type === 'item.content_part.delta') {
@@ -597,7 +597,7 @@ function parseCodexOutputText(ev: Record<string, unknown>): string | null {
 
 async function runCodexDelegate(binary: string, task: string, resume: boolean, resumeId: string, bctx: DelegateContext, runtime?: DelegateRuntimeState): Promise<string> {
   try {
-    // Build clean env — preserves user's CODEX_HOME for auth
+    // Build clean env â€” preserves user's CODEX_HOME for auth
     const env = buildCliEnv()
 
     // Auth probe BEFORE any temp CODEX_HOME override
@@ -936,7 +936,7 @@ const DelegateExtension: Extension = {
         },
         required: []
       },
-      execute: async (args, context) => executeDelegateAction(args, buildDelegateContextFromSessionish(context.session))
+      execute: async (args, context) => executeDelegateAction(args as Record<string, unknown>, buildDelegateContextFromSessionish(context.session))
     }
   ]
 }
@@ -953,7 +953,7 @@ export function buildDelegateTools(bctx: ToolBuildContext): StructuredToolInterf
   if (bctx.ctx?.delegationEnabled && hasExtension('delegate')) {
     tools.push(
       tool(
-        async (args) => executeDelegateAction(args, bctx),
+        async (args) => executeDelegateAction(args as Record<string, unknown>, bctx),
         {
           name: 'delegate',
           description: DelegateExtension.tools![0].description,

--- a/src/lib/server/session-tools/discovery.ts
+++ b/src/lib/server/session-tools/discovery.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+﻿import { z } from 'zod'
 import { tool, type StructuredToolInterface } from '@langchain/core/tools'
 import type { ToolBuildContext } from './context'
 import { getExtensionManager, normalizeMarketplaceExtensionUrl } from '../extensions'
@@ -256,7 +256,7 @@ const DiscoveryExtension: Extension = {
         },
         required: ['action', 'reason']
       },
-      execute: async (args) => executeDiscoveryAction(args)
+      execute: async (args) => executeDiscoveryAction(args as Record<string, unknown>)
     }
   ]
 }
@@ -267,7 +267,7 @@ export function buildDiscoveryTools(bctx: ToolBuildContext): StructuredToolInter
   // Always allow agents to discover what they can do
   return [
     tool(
-      async (args) => executeDiscoveryAction(args, bctx),
+      async (args) => executeDiscoveryAction(args as Record<string, unknown>, bctx),
       {
         name: 'manage_capabilities',
         description: DiscoveryExtension.tools![0].description,

--- a/src/lib/server/session-tools/extension-creator.ts
+++ b/src/lib/server/session-tools/extension-creator.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+﻿import { z } from 'zod'
 import { tool, type StructuredToolInterface } from '@langchain/core/tools'
 import fs from 'fs'
 import path from 'path'
@@ -158,7 +158,7 @@ Key rules:
 - Export SwarmClaw hooks/tools. Add register(api) too if you want OpenClaw compatibility.
 - SwarmClaw checks hooks/tools first; OpenClaw checks register()
 - Tools must have name, description, parameters (JSON Schema), and execute function
-- Hooks are optional — only include the ones you need
+- Hooks are optional â€” only include the ones you need
 - If your extension needs npm/pnpm/yarn/bun packages, include a packageJson object during scaffold or call install_dependencies later.
 - Dependency installs are run by the extension manager inside a per-extension workspace using the selected package manager with scripts disabled.
 - Extension settings are declared through ui.settingsFields and stored per extension ID
@@ -251,7 +251,7 @@ export function buildExtensionCreatorTools(bctx: ToolBuildContext): StructuredTo
   if (!bctx.hasExtension('extension_creator')) return []
   return [
     tool(
-      async (args) => executeExtensionCreatorAction(args, bctx),
+      async (args) => executeExtensionCreatorAction(args as Record<string, unknown>, bctx),
       {
         name: 'extension_creator_tool',
         description: ExtensionCreatorExtension.tools![0].description,

--- a/src/lib/server/session-tools/file.ts
+++ b/src/lib/server/session-tools/file.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+﻿import { z } from 'zod'
 import { tool, type StructuredToolInterface } from '@langchain/core/tools'
 import fs from 'fs'
 import path from 'path'
@@ -504,7 +504,7 @@ const FileExtension: Extension = {
         },
         required: ['action']
       },
-      execute: async (args, context) => executeFileAction(args, { cwd: context.session.cwd || process.cwd() })
+      execute: async (args, context) => executeFileAction(args as Record<string, unknown>, { cwd: context.session.cwd || process.cwd() })
     },
     {
       name: 'send_file',
@@ -542,7 +542,7 @@ export function buildFileTools(bctx: ToolBuildContext): StructuredToolInterface[
 
   return [
     tool(
-      async (args) => executeFileAction(args, { cwd: bctx.cwd, filesystemScope: bctx.filesystemScope }),
+      async (args) => executeFileAction(args as Record<string, unknown>, { cwd: bctx.cwd, filesystemScope: bctx.filesystemScope }),
       {
         name: 'files',
         description: FileExtension.tools![0].description,

--- a/src/lib/server/session-tools/google-workspace.ts
+++ b/src/lib/server/session-tools/google-workspace.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs'
+﻿import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { spawn, type ChildProcess } from 'node:child_process'
@@ -381,7 +381,7 @@ const GoogleWorkspaceExtension: Extension = {
         },
         required: ['args'],
       },
-      execute: async (args) => executeGoogleWorkspaceAction(args),
+      execute: async (args) => executeGoogleWorkspaceAction(args as Record<string, unknown>),
     },
   ],
 }

--- a/src/lib/server/session-tools/human-loop.ts
+++ b/src/lib/server/session-tools/human-loop.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+﻿import { z } from 'zod'
 import { tool, type StructuredToolInterface } from '@langchain/core/tools'
 import type { Extension, ExtensionHooks } from '@/types'
 import type { ToolBuildContext } from './context'
@@ -254,7 +254,7 @@ const HumanLoopExtension: Extension = {
         },
         required: ['action'],
       },
-      execute: async (args, context) => executeHumanLoopAction(args, {
+      execute: async (args, context) => executeHumanLoopAction(args as Record<string, unknown>, {
         sessionId: context.session.id,
         agentId: context.session.agentId || null,
       }),
@@ -268,7 +268,7 @@ export function buildHumanLoopTools(bctx: ToolBuildContext): StructuredToolInter
   if (!bctx.hasExtension('ask_human')) return []
   return [
     tool(
-      async (args) => executeHumanLoopAction(args, {
+      async (args) => executeHumanLoopAction(args as Record<string, unknown>, {
         sessionId: bctx.ctx?.sessionId || null,
         agentId: bctx.ctx?.agentId || null,
       }),

--- a/src/lib/server/session-tools/mailbox.ts
+++ b/src/lib/server/session-tools/mailbox.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+﻿import { z } from 'zod'
 import { tool, type StructuredToolInterface } from '@langchain/core/tools'
 import type { Extension, ExtensionHooks } from '@/types'
 import { getExtensionManager } from '../extensions'
@@ -234,7 +234,7 @@ const MailboxExtension: Extension = {
         },
         required: ['action'],
       },
-      execute: async (args, context) => executeMailboxAction(args, {
+      execute: async (args, context) => executeMailboxAction(args as Record<string, unknown>, {
         cwd: context.session.cwd || process.cwd(),
         sessionId: context.session.id,
         agentId: context.session.agentId || null,
@@ -262,7 +262,7 @@ export function buildMailboxTools(bctx: ToolBuildContext): StructuredToolInterfa
   if (!bctx.hasExtension('mailbox')) return []
   return [
     tool(
-      async (args) => executeMailboxAction(args, {
+      async (args) => executeMailboxAction(args as Record<string, unknown>, {
         cwd: bctx.cwd,
         sessionId: bctx.ctx?.sessionId || null,
         agentId: bctx.ctx?.agentId || null,

--- a/src/lib/server/session-tools/memory.ts
+++ b/src/lib/server/session-tools/memory.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+﻿import { z } from 'zod'
 import { tool } from '@langchain/core/tools'
 import fs from 'fs'
 import { genId } from '@/lib/id'
@@ -496,7 +496,7 @@ export async function executeMemoryAction(input: unknown, ctx: MemoryActionConte
 
   const formatEntry = (m: MemoryEntry) => {
     let line = `[${m.id}] (${m.agentId ? `agent:${m.agentId}` : 'shared'}) ${m.category}/${m.title}: ${m.content}`
-    if (m.reinforcementCount) line += ` (reinforced ×${m.reinforcementCount})`
+    if (m.reinforcementCount) line += ` (reinforced Ã—${m.reinforcementCount})`
     if (m.references?.length) {
       line += `\n  refs: ${m.references.map((r: MemoryReference) => `${r.type}:${r.path || r.title || r.type}`).join(', ')}`
     }
@@ -724,7 +724,7 @@ const MemoryExtension: Extension = {
 
       const pinnedLines = pinned.filter(dedup).map(formatMemoryLine)
 
-      // Fetch identity/* category memories — only in private (DM/peer) contexts
+      // Fetch identity/* category memories â€” only in private (DM/peer) contexts
       const identityMemories = isPrivateContext
         ? allRecent.filter((m) => m.category?.startsWith('identity/') && dedup(m))
         : []
@@ -863,7 +863,7 @@ const MemoryExtension: Extension = {
         '- What I\'ve discovered about projects, codebases, or environments',
         '- Problems I\'ve hit and how I solved them',
         '- Who people are and how they relate to each other',
-        '- Contact details: phone numbers, emails, platform IDs — use category "contacts"',
+        '- Contact details: phone numbers, emails, platform IDs â€” use category "contacts"',
         '- Configuration details and environment specifics that I\'ll need again',
         '',
         '**Not worth cluttering my memory with:**',
@@ -872,20 +872,20 @@ const MemoryExtension: Extension = {
         '- Things already in my system prompt',
         '- Something I\'ve already stored',
         '',
-        '**Categories** — pick the one that fits best when storing:',
-        '- `identity/preferences` — Likes, dislikes, style choices, timezone, pronouns, and personal preferences',
-        '- `identity/relationships` — Who people are and how they relate to each other',
-        '- `identity/contacts` — Phone numbers, emails, platform IDs for matching senders',
-        '- `identity/routines` — Recurring patterns: "picks up kids at 3pm", "checks in every morning"',
-        '- `identity/goals` — What the user is working toward: "launch MVP by Q2", "learn Spanish"',
-        '- `identity/events` — Significant life events: illness, birth, wedding, promotion, loss',
-        '- `knowledge/instructions` — Standing directives: "always respond in English", "use metric units"',
-        '- `knowledge/facts` — General knowledge, references, documentation',
-        '- `projects/decisions` — Decisions made and why',
-        '- `projects/learnings` — Lessons learned, solved problems, post-mortems',
-        '- `projects/context` — Project details, milestones, roadmap',
-        '- `operations/environment` — Config, credentials, endpoints, infrastructure',
-        '- `working/scratch` — Temporary notes that\'ll change soon',
+        '**Categories** â€” pick the one that fits best when storing:',
+        '- `identity/preferences` â€” Likes, dislikes, style choices, timezone, pronouns, and personal preferences',
+        '- `identity/relationships` â€” Who people are and how they relate to each other',
+        '- `identity/contacts` â€” Phone numbers, emails, platform IDs for matching senders',
+        '- `identity/routines` â€” Recurring patterns: "picks up kids at 3pm", "checks in every morning"',
+        '- `identity/goals` â€” What the user is working toward: "launch MVP by Q2", "learn Spanish"',
+        '- `identity/events` â€” Significant life events: illness, birth, wedding, promotion, loss',
+        '- `knowledge/instructions` â€” Standing directives: "always respond in English", "use metric units"',
+        '- `knowledge/facts` â€” General knowledge, references, documentation',
+        '- `projects/decisions` â€” Decisions made and why',
+        '- `projects/learnings` â€” Lessons learned, solved problems, post-mortems',
+        '- `projects/context` â€” Project details, milestones, roadmap',
+        '- `operations/environment` â€” Config, credentials, endpoints, infrastructure',
+        '- `working/scratch` â€” Temporary notes that\'ll change soon',
         '',
         '**Good habits:**',
         '- Give memories clear titles ("User prefers dark mode" not "Note 1")',
@@ -912,7 +912,7 @@ const MemoryExtension: Extension = {
       const MAX_MEMORY_INJECTION_CHARS = 8000
       const combined = parts.join('\n\n')
       if (combined.length > MAX_MEMORY_INJECTION_CHARS) {
-        // Keep whole parts within budget — drop lowest-priority parts entirely rather than slicing mid-content
+        // Keep whole parts within budget â€” drop lowest-priority parts entirely rather than slicing mid-content
         let budget = MAX_MEMORY_INJECTION_CHARS
         const prioritized: string[] = []
         for (const part of parts) {
@@ -920,7 +920,7 @@ const MemoryExtension: Extension = {
             prioritized.push(part)
             budget -= part.length
           } else if (budget > 0 && prioritized.length === 0) {
-            // First part exceeds budget — truncate at last newline within budget to avoid mid-word cuts
+            // First part exceeds budget â€” truncate at last newline within budget to avoid mid-word cuts
             const truncAt = part.lastIndexOf('\n', budget)
             prioritized.push(truncAt > 0 ? part.slice(0, truncAt) : part.slice(0, budget))
             budget = 0
@@ -998,9 +998,9 @@ const MemoryExtension: Extension = {
         ctx.session.lastAutoMemoryAt = now
       } catch { /* auto-memory is best-effort */ }
     },
-    getCapabilityDescription: () => 'I have long-term memory (`memory_search`, `memory_get`, `memory_store`, `memory_update`, `memory_tool`) — I can remember things across conversations and recall them when needed.',
+    getCapabilityDescription: () => 'I have long-term memory (`memory_search`, `memory_get`, `memory_store`, `memory_update`, `memory_tool`) â€” I can remember things across conversations and recall them when needed.',
     getOperatingGuidance: () => [
-      'Memory: use narrow memory tools first. For past-conversation recall, prefer `memory_search` then `memory_get`. For direct writes or corrections, prefer `memory_store` or `memory_update`. Keep `memory_tool` for list/delete/link/doctor or when you truly need the generic surface. NEVER use memory tools to create files, CSV data, code, or documents — always use the `files` tool for those.',
+      'Memory: use narrow memory tools first. For past-conversation recall, prefer `memory_search` then `memory_get`. For direct writes or corrections, prefer `memory_store` or `memory_update`. Keep `memory_tool` for list/delete/link/doctor or when you truly need the generic surface. NEVER use memory tools to create files, CSV data, code, or documents â€” always use the `files` tool for those.',
       'For info already in the current conversation, respond directly without calling any memory tool.',
       'For questions about prior work, decisions, dates, people, preferences, or todos from earlier conversations: start with one durable `memory_search`, then use `memory_get` only if you need a more targeted read. Only use archive/session history when the user explicitly needs transcript-level detail or the durable search is insufficient.',
       'When the user directly says to remember, store, or correct a fact, do one `memory_store` or `memory_update` call immediately. Treat the newest direct user statement as authoritative.',
@@ -1008,7 +1008,7 @@ const MemoryExtension: Extension = {
       'If someone says "remember this", write it down; do not rely on RAM alone.',
       'Memory writes merge canonical memories and retire superseded variants. After a successful store/update, do not keep re-searching unless the user explicitly asked you to verify.',
       'By default, memory searches focus on durable memories. Only include archives or working execution notes when you explicitly need transcript or run-history context.',
-      'For open goals, form a hypothesis and execute — do not keep re-asking broad questions.',
+      'For open goals, form a hypothesis and execute â€” do not keep re-asking broad questions.',
     ],
   } as ExtensionHooks,
   tools: [
@@ -1032,7 +1032,7 @@ const MemoryExtension: Extension = {
         required: ['action']
       },
       execute: async (args, context) => {
-        return executeMemoryAction(args, context.session)
+        return executeMemoryAction(args as Record<string, unknown>, context.session)
       },
       planning: {
         capabilities: ['memory.search', 'memory.write'],
@@ -1084,7 +1084,7 @@ const MemoryExtension: Extension = {
     },
     {
       name: 'memory_store',
-      description: 'Store a durable fact, preference, decision, or correction from the user. Use this immediately when the user says to remember something. If several related facts arrive in one request, prefer one canonical write over many near-duplicate calls. NOT for writing files, documents, code, or data exports — use the files tool for those.',
+      description: 'Store a durable fact, preference, decision, or correction from the user. Use this immediately when the user says to remember something. If several related facts arrive in one request, prefer one canonical write over many near-duplicate calls. NOT for writing files, documents, code, or data exports â€” use the files tool for those.',
       parameters: {
         type: 'object',
         properties: {
@@ -1119,7 +1119,7 @@ const MemoryExtension: Extension = {
         const looksLikeCode = /^(import |export |function |const |let |var |class |interface |type |def |from |#include|package |using )/m.test(value)
         const looksLikeCsv = lineCount >= 3 && (value.match(/,/g) || []).length >= lineCount * 2
         const looksLikeStructuredData = lineCount >= 5 && (/^\s*[\[{]/m.test(value) || looksLikeCsv)
-        const redirectMsg = 'Error: memory_store is only for remembering facts, preferences, and decisions — NOT for creating files, CSV data, code, or documents. To write a file, use the `files` tool: files({action:"write", files:[{path:"path/to/file", content:"..."}]})'
+        const redirectMsg = 'Error: memory_store is only for remembering facts, preferences, and decisions â€” NOT for creating files, CSV data, code, or documents. To write a file, use the `files` tool: files({action:"write", files:[{path:"path/to/file", content:"..."}]})'
         if (hasFileExtension || hasFilePath || (mentionsFileOp && (!value || value.length > 200))) {
           return redirectMsg
         }
@@ -1164,7 +1164,7 @@ export function buildMemoryTools(bctx: ToolBuildContext) {
   
   return [
     tool(
-      async (args) => executeMemoryAction(args, bctx.ctx),
+      async (args) => executeMemoryAction(args as Record<string, unknown>, bctx.ctx),
       {
         name: 'memory_tool',
         description: MemoryExtension.tools![0].description,

--- a/src/lib/server/session-tools/monitor.ts
+++ b/src/lib/server/session-tools/monitor.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+﻿import { z } from 'zod'
 import { tool, type StructuredToolInterface } from '@langchain/core/tools'
 import type { ToolBuildContext } from './context'
 import { registerNativeCapability } from '../native-capabilities'
@@ -184,7 +184,7 @@ const MonitorExtension: Extension = {
         },
         required: ['action']
       },
-      execute: async (args, context) => executeMonitorAction(args, {
+      execute: async (args, context) => executeMonitorAction(args as Record<string, unknown>, {
         cwd: context.session.cwd || process.cwd(),
         sessionId: context.session.id,
         agentId: context.session.agentId,
@@ -199,7 +199,7 @@ export function buildMonitorTools(bctx: ToolBuildContext): StructuredToolInterfa
   if (!bctx.hasExtension('monitor')) return []
   return [
     tool(
-      async (args) => executeMonitorAction(args, {
+      async (args) => executeMonitorAction(args as Record<string, unknown>, {
         cwd: bctx.cwd,
         sessionId: bctx.ctx?.sessionId || undefined,
         agentId: bctx.ctx?.agentId || undefined,

--- a/src/lib/server/session-tools/openclaw-nodes.ts
+++ b/src/lib/server/session-tools/openclaw-nodes.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+﻿import { z } from 'zod'
 import { randomUUID } from 'crypto'
 import { tool, type StructuredToolInterface } from '@langchain/core/tools'
 import type { ToolBuildContext } from './context'
@@ -136,7 +136,7 @@ const NodesExtension: Extension = {
         },
         required: ['action']
       },
-      execute: async (args) => executeNodesAction(args)
+      execute: async (args) => executeNodesAction(args as Record<string, unknown>)
     }
   ]
 }
@@ -150,7 +150,7 @@ export function buildOpenClawNodeTools(bctx: ToolBuildContext): StructuredToolIn
   if (!bctx.hasExtension('openclaw_nodes')) return []
   return [
     tool(
-      async (args) => executeNodesAction(args),
+      async (args) => executeNodesAction(args as Record<string, unknown>),
       {
         name: 'openclaw_nodes',
         description: NodesExtension.tools![0].description,

--- a/src/lib/server/session-tools/openclaw-workspace.ts
+++ b/src/lib/server/session-tools/openclaw-workspace.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+﻿import { z } from 'zod'
 import { tool, type StructuredToolInterface } from '@langchain/core/tools'
 import { execFile } from 'child_process'
 import { promisify } from 'util'
@@ -117,7 +117,7 @@ const WorkspaceExtension: Extension = {
         },
         required: ['action']
       },
-      execute: async (args) => executeWorkspaceAction(args)
+      execute: async (args) => executeWorkspaceAction(args as Record<string, unknown>)
     }
   ]
 }
@@ -131,7 +131,7 @@ export function buildOpenClawWorkspaceTools(bctx: ToolBuildContext): StructuredT
   if (!bctx.hasExtension('openclaw_workspace')) return []
   return [
     tool(
-      async (args) => executeWorkspaceAction(args),
+      async (args) => executeWorkspaceAction(args as Record<string, unknown>),
       {
         name: 'openclaw_workspace',
         description: WorkspaceExtension.tools![0].description,

--- a/src/lib/server/session-tools/platform.ts
+++ b/src/lib/server/session-tools/platform.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+﻿import { z } from 'zod'
 import { tool, type StructuredToolInterface } from '@langchain/core/tools'
 import { buildCrudTools } from './crud'
 import type { ToolBuildContext } from './context'
@@ -242,7 +242,7 @@ const PlatformExtension: Extension = {
         },
         required: ['resource', 'action']
       },
-      execute: async (args, context) => executePlatformAction(args, buildPlatformContextFromSession(context.session))
+      execute: async (args, context) => executePlatformAction(args as Record<string, unknown>, buildPlatformContextFromSession(context.session))
     }
   ]
 }
@@ -257,7 +257,7 @@ export function buildPlatformTools(bctx: ToolBuildContext): StructuredToolInterf
 
   return [
     tool(
-      async (args) => executePlatformAction(args, bctx),
+      async (args) => executePlatformAction(args as Record<string, unknown>, bctx),
       {
         name: 'manage_platform',
         description: PlatformExtension.tools![0].description,

--- a/src/lib/server/session-tools/protocol.ts
+++ b/src/lib/server/session-tools/protocol.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+﻿import { z } from 'zod'
 import { tool, type StructuredToolInterface } from '@langchain/core/tools'
 import type { ToolBuildContext } from './context'
 import type { Extension, ExtensionHooks } from '@/types'
@@ -211,7 +211,7 @@ const ProtocolExtension: Extension = {
   description: 'Structured orchestration workflows: sequential, parallel, branching, looping, DAG, forEach, subflows, and swarm patterns.',
   hooks: {
     getCapabilityDescription: () =>
-      'I can run structured orchestration workflows (`manage_protocols`) — conditional branching, looping, DAG dependencies, dynamic parallel (forEach), subflows, and competitive swarm patterns.',
+      'I can run structured orchestration workflows (`manage_protocols`) â€” conditional branching, looping, DAG dependencies, dynamic parallel (forEach), subflows, and competitive swarm patterns.',
     getOperatingGuidance: () => [
       'Step kinds: present, collect_independent_inputs, round_robin, compare, decide, summarize, emit_tasks, wait, dispatch_task, dispatch_delegation, branch, repeat, parallel, join, complete, for_each, subflow, swarm_claim.',
       'Each step requires `id`, `kind`, `label`. Chain steps with `nextStepId`. Per-kind config: `branchCases[]` + `defaultNextStepId` (branch), `repeat` (repeat), `parallel` (parallel), `forEach` (for_each), `subflow` (subflow), `swarm` (swarm_claim).',
@@ -243,7 +243,7 @@ const ProtocolExtension: Extension = {
         required: ['action'],
       },
       execute: async (args, context) =>
-        executeProtocolAction(args, { sessionId: (context.session as unknown as Record<string, unknown>).sessionId as string | undefined }),
+        executeProtocolAction(args as Record<string, unknown>, { sessionId: (context.session as unknown as Record<string, unknown>).sessionId as string | undefined }),
     },
   ],
 }
@@ -257,7 +257,7 @@ export function buildProtocolTools(bctx: ToolBuildContext): StructuredToolInterf
   if (!bctx.hasExtension('manage_protocols')) return []
   return [
     tool(
-      async (args) => executeProtocolAction(args, { sessionId: bctx.ctx?.sessionId }),
+      async (args) => executeProtocolAction(args as Record<string, unknown>, { sessionId: bctx.ctx?.sessionId }),
       {
         name: 'manage_protocols',
         description: ProtocolExtension.tools![0].description,

--- a/src/lib/server/session-tools/session-info.ts
+++ b/src/lib/server/session-tools/session-info.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+﻿import { z } from 'zod'
 import { tool, type StructuredToolInterface } from '@langchain/core/tools'
 import { genId } from '@/lib/id'
 import { loadSessions, saveSessions, loadAgents } from '../storage'
@@ -133,7 +133,7 @@ const SessionInfoExtension: Extension = {
   name: 'Core Session Info',
   description: 'Identify current session context and manage other agent sessions.',
   hooks: {
-    getCapabilityDescription: () => 'I can manage chat sessions (`sessions_tool`) — check my identity with action `identity`, look up past conversations, spawn sessions, and coordinate work.',
+    getCapabilityDescription: () => 'I can manage chat sessions (`sessions_tool`) â€” check my identity with action `identity`, look up past conversations, spawn sessions, and coordinate work.',
     getOperatingGuidance: () => 'Inspect existing chats before creating duplicates.',
   } as ExtensionHooks,
   tools: [
@@ -152,7 +152,7 @@ const SessionInfoExtension: Extension = {
         },
         required: ['action']
       },
-      execute: async (args, context) => executeSessionsAction(args, { sessionId: context.session.id, agentId: context.session.agentId ?? undefined, cwd: context.session.cwd || process.cwd() })
+      execute: async (args, context) => executeSessionsAction(args as Record<string, unknown>, { sessionId: context.session.id, agentId: context.session.agentId ?? undefined, cwd: context.session.cwd || process.cwd() })
     }
   ]
 }
@@ -166,7 +166,7 @@ export function buildSessionInfoTools(bctx: ToolBuildContext): StructuredToolInt
   if (!bctx.hasExtension('manage_sessions')) return []
   return [
     tool(
-      async (args) => executeSessionsAction(args, { sessionId: bctx.ctx?.sessionId || undefined, agentId: bctx.ctx?.agentId || undefined, cwd: bctx.cwd }),
+      async (args) => executeSessionsAction(args as Record<string, unknown>, { sessionId: bctx.ctx?.sessionId || undefined, agentId: bctx.ctx?.agentId || undefined, cwd: bctx.cwd }),
       { name: 'sessions_tool', description: SessionInfoExtension.tools![0].description, schema: z.object({}).passthrough() }
     )
   ]

--- a/src/lib/server/session-tools/shell.ts
+++ b/src/lib/server/session-tools/shell.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+﻿import { z } from 'zod'
 import { tool } from '@langchain/core/tools'
 import fs from 'fs'
 import {
@@ -151,7 +151,7 @@ export function normalizeShellArgs(rawArgs: Record<string, unknown>): Record<str
 /**
  * Extract file path operands from common shell commands.
  * Covers cat, rm, cp, mv, tee, and redirections (>, >>).
- * Returns best-effort paths — won't catch variable expansion or complex pipelines.
+ * Returns best-effort paths â€” won't catch variable expansion or complex pipelines.
  */
 function extractShellFileTargets(command: string): string[] {
   const paths: string[] = []
@@ -380,7 +380,7 @@ const ShellExtension: Extension = {
   description: 'Execute shell commands and manage background processes. Use for git, curl, and other CLI tools.',
   hooks: {
     getCapabilityDescription: () => 'I can run shell commands with the unified `shell` tool. Use action `execute` for commands (including git, curl, and other CLI tools), `sandbox_exec` to run JS/TS in a sandboxed environment, and `list` / `status` / `poll` / `log` for long-lived processes.',
-    getOperatingGuidance: () => ['Shell: use `shell` with `{"action":"execute","command":"..."}` for servers, installs, scripts, git, and curl. Use `background=true` for long-lived processes.', 'Use `shell` with `{"action":"sandbox_exec","language":"javascript","code":"..."}` to run JS/TS in a Docker sandbox when available.', 'Verify servers with `shell` status/log actions and liveness probes before claiming success.', 'Resolve IPs/URLs via shell — never use placeholders. Retry path errors without workdir override.'],
+    getOperatingGuidance: () => ['Shell: use `shell` with `{"action":"execute","command":"..."}` for servers, installs, scripts, git, and curl. Use `background=true` for long-lived processes.', 'Use `shell` with `{"action":"sandbox_exec","language":"javascript","code":"..."}` to run JS/TS in a Docker sandbox when available.', 'Verify servers with `shell` status/log actions and liveness probes before claiming success.', 'Resolve IPs/URLs via shell â€” never use placeholders. Retry path errors without workdir override.'],
   } as ExtensionHooks,
   tools: [
     {
@@ -398,7 +398,7 @@ const ShellExtension: Extension = {
         },
         required: ['action']
       },
-      execute: async (args, context) => executeShellAction(args, { ...context.session, cwd: context.session.cwd || process.cwd() })
+      execute: async (args, context) => executeShellAction(args as Record<string, unknown>, { ...context.session, cwd: context.session.cwd || process.cwd() })
     }
   ]
 }
@@ -409,7 +409,7 @@ export function buildShellTools(bctx: ToolBuildContext) {
   if (!bctx.hasExtension('shell')) return []
   return [
     tool(
-      async (args) => executeShellAction(args, {
+      async (args) => executeShellAction(args as Record<string, unknown>, {
         ...bctx.ctx,
         cwd: bctx.cwd,
         resolveCurrentSession: bctx.resolveCurrentSession,

--- a/src/lib/server/session-tools/subagent.ts
+++ b/src/lib/server/session-tools/subagent.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+﻿import { z } from 'zod'
 import { tool, type StructuredToolInterface } from '@langchain/core/tools'
 import type { ToolBuildContext } from './context'
 import type { Extension, ExtensionHooks } from '@/types'
@@ -180,7 +180,7 @@ async function waitForJob(jobId: string, timeoutSec = 30): Promise<string> {
       sleep(timeoutMs).then(() => null),
     ])
     if (result) return JSON.stringify(result)
-    // Timed out — return current job state with explicit timeout indicator
+    // Timed out â€” return current job state with explicit timeout indicator
     const job = getDelegationJob(jobId)
     if (job) return JSON.stringify({ ...job, _timedOut: true })
     return `Error: delegation job "${jobId}" not found.`
@@ -263,7 +263,7 @@ async function handleBatch(args: Record<string, unknown>, ctx: ActionContext): P
     ? args.executionMode
     : 'auto'
 
-  // Use spawnSwarm internally — batch is a simplified interface
+  // Use spawnSwarm internally â€” batch is a simplified interface
   const swarm = await spawnSwarm({ tasks, executionMode }, { sessionId: ctx.sessionId, cwd: ctx.cwd })
   const jobIds = swarm.members
     .filter((m) => !m.spawnError && m.handle)
@@ -436,7 +436,7 @@ const ACTIONS: Record<string, ActionHandler> = {
 }
 
 /**
- * Core Subagent Execution Logic — powered by native subagent runtime.
+ * Core Subagent Execution Logic â€” powered by native subagent runtime.
  * Uses dispatch map instead of if-else chain for maintainability.
  */
 async function executeSubagentAction(args: unknown, context: ActionContext) {
@@ -469,12 +469,12 @@ const SubagentExtension: Extension = {
       + 'Background swarms return a swarmId you can pass to swarm_status, swarm_list, and swarm_cancel.',
     getOperatingGuidance: () => [
       'SUBAGENT DISPATCH RULES:',
-      '- Single task → action "start" with agentId + message.',
-      '- 2+ independent tasks → action "batch" with tasks array [{agentId, message}, ...]. Use `executionMode:"serial"` when local models are rate-limited.',
-      '- Background coordination example → `{"action":"swarm","tasks":[...],"background":true}` and then read the returned `swarmId` before calling `swarm_status` or `swarm_cancel`.',
+      '- Single task â†’ action "start" with agentId + message.',
+      '- 2+ independent tasks â†’ action "batch" with tasks array [{agentId, message}, ...]. Use `executionMode:"serial"` when local models are rate-limited.',
+      '- Background coordination example â†’ `{"action":"swarm","tasks":[...],"background":true}` and then read the returned `swarmId` before calling `swarm_status` or `swarm_cancel`.',
       '- If your final answer depends on all delegated results, set `waitForCompletion:true` and do not summarize early.',
       '- Prefer one coordinated `batch`/`swarm` call over mixing `start`, `delegate`, and follow-up retries for the same set of sibling tasks.',
-      '- DO NOT call "start" in a loop when tasks are independent — use "batch" or "swarm" instead.',
+      '- DO NOT call "start" in a loop when tasks are independent â€” use "batch" or "swarm" instead.',
       '- Only use subagents when the task genuinely requires another agent\'s specialization or parallel execution.',
       '- If you can answer directly from your own knowledge, do NOT spawn a subagent.',
     ],
@@ -532,7 +532,7 @@ const SubagentExtension: Extension = {
         },
         required: []
       },
-      execute: async (args, context) => executeSubagentAction(args, { sessionId: context.session.id, cwd: context.session.cwd || process.cwd() })
+      execute: async (args, context) => executeSubagentAction(args as Record<string, unknown>, { sessionId: context.session.id, cwd: context.session.cwd || process.cwd() })
     }
   ]
 }
@@ -561,7 +561,7 @@ export function buildSubagentTools(bctx: ToolBuildContext): StructuredToolInterf
 
   return [
     tool(
-      async (args) => executeSubagentAction(args, {
+      async (args) => executeSubagentAction(args as Record<string, unknown>, {
         sessionId: bctx.ctx?.sessionId || undefined,
         cwd: bctx.cwd,
         delegationTargetMode: bctx.ctx?.delegationTargetMode,

--- a/src/lib/server/session-tools/wallet.ts
+++ b/src/lib/server/session-tools/wallet.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+﻿import { z } from 'zod'
 import { tool, type StructuredToolInterface } from '@langchain/core/tools'
 import crypto from 'node:crypto'
 
@@ -1284,7 +1284,7 @@ const WalletExtension: Extension = {
         },
         required: ['action'],
       },
-      execute: async (args, context) => executeWalletAction(args, { agentId: context.session.agentId, sessionId: context.session.id }),
+      execute: async (args, context) => executeWalletAction(args as Record<string, unknown>, { agentId: context.session.agentId, sessionId: context.session.id }),
     },
   ],
 }
@@ -1295,7 +1295,7 @@ export function buildWalletTools(bctx: ToolBuildContext): StructuredToolInterfac
   if (!bctx.hasExtension('wallet')) return []
   return [
     tool(
-      async (args) => executeWalletAction(args, { agentId: bctx.ctx?.agentId, sessionId: bctx.ctx?.sessionId }),
+      async (args) => executeWalletAction(args as Record<string, unknown>, { agentId: bctx.ctx?.agentId, sessionId: bctx.ctx?.sessionId }),
       {
         name: 'wallet_tool',
         description: WalletExtension.tools![0].description,

--- a/src/lib/server/session-tools/web.ts
+++ b/src/lib/server/session-tools/web.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+﻿import { z } from 'zod'
 import { tool, type StructuredToolInterface } from '@langchain/core/tools'
 import fs from 'fs'
 import path from 'path'
@@ -87,7 +87,7 @@ type BrowserMcpClient = {
   close?: () => void | Promise<void>
 }
 
-// Stored on globalThis to survive HMR reloads in dev mode —
+// Stored on globalThis to survive HMR reloads in dev mode â€”
 // prevents orphaned Chromium processes when web.ts is edited.
 export const activeBrowsers: Map<string, BrowserRuntimeEntry> =
   hmrSingleton('__swarmclaw_active_browsers__', () => new Map<string, BrowserRuntimeEntry>())
@@ -282,7 +282,7 @@ const WebExtension: Extension = {
         },
         required: ['action']
       },
-      execute: async (args) => executeWebAction(args)
+      execute: async (args) => executeWebAction(args as Record<string, unknown>)
     }
   ]
 }
@@ -299,7 +299,7 @@ export function buildWebTools(bctx: ToolBuildContext): StructuredToolInterface[]
   if (bctx.hasExtension('web')) {
     tools.push(
       tool(
-        async (args) => executeWebAction(args),
+        async (args) => executeWebAction(args as Record<string, unknown>),
         {
           name: 'web',
           description: WebExtension.tools![0].description,
@@ -953,7 +953,7 @@ export function buildWebTools(bctx: ToolBuildContext): StructuredToolInterface[]
         const buttonSelector = 'button, a[role="button"], [role="button"], input[type="button"], input[type="submit"]';
         const rejectRe = /^(reject|reject all|decline|decline all|deny|deny all|refuse|no,? thanks|only necessary|necessary only|use necessary cookies only)$/i;
         const acceptRe = /^(accept|accept all|allow all|agree|i agree|okay|ok|got it|continue|consent)$/i;
-        const closeRe = /^(close|dismiss|skip|not now|x|×)$/i;
+        const closeRe = /^(close|dismiss|skip|not now|x|Ã—)$/i;
         const clickMatching = (matcher, label) => {
           for (const root of allRoots) {
             let buttons = [];


### PR DESCRIPTION
Fixes TypeScript build errors where LangChain's tool() callback passes args as 'unknown' but execute*Action functions expect 'Record<string, unknown>'.