### PR TITLE
fix: use $SHELL instead of hardcoded /bin/zsh for subprocess spawning

### DIFF
--- a/src/lib/server/provider-health.ts
+++ b/src/lib/server/provider-health.ts
@@ -42,7 +42,7 @@ function commandExists(binary: string): boolean {
   pruneTTLCache(cliCheckCache, CLI_CHECK_TTL_MS, CLI_CHECK_CACHE_MAX)
   const probe = isWindows
     ? spawnSync('where', [binary], { timeout: 2000, stdio: 'pipe' })
-    : spawnSync('/bin/zsh', ['-lc', `command -v ${binary} >/dev/null 2>&1`], { timeout: 2000 })
+    : spawnSync(process.env.SHELL || '/bin/bash', ['-lc', `command -v ${binary} >/dev/null 2>&1`], { timeout: 2000 })
   const ok = (probe.status ?? 1) === 0
   cliCheckCache.set(binary, { at: now, ok })
   return ok

--- a/src/lib/server/runtime/process-manager.ts
+++ b/src/lib/server/runtime/process-manager.ts
@@ -169,7 +169,8 @@ export function buildDockerExecArgs(params: {
 
 export function getShellCommand(command: string, processId?: string, sandbox?: SandboxOptions): { shell: string; args: string[]; containerName?: string } {
   if (!sandbox) {
-    return { shell: '/bin/zsh', args: ['-lc', command] }
+    const shell = process.env.SHELL || '/bin/bash'
+    return { shell, args: ['-lc', command] }
   }
 
   if (sandbox.kind === 'persistent') {

--- a/src/lib/server/session-tools/context.ts
+++ b/src/lib/server/session-tools/context.ts
@@ -190,7 +190,7 @@ export function findBinaryOnPath(binaryName: string): string | null {
   const { spawnSync } = require('child_process')
   const probe = isWindows
     ? spawnSync('where', [binaryName], { encoding: 'utf-8', timeout: 2000, stdio: 'pipe' })
-    : spawnSync('/bin/zsh', ['-lc', `command -v ${binaryName} 2>/dev/null`], { encoding: 'utf-8', timeout: 2000 })
+    : spawnSync(process.env.SHELL || '/bin/bash', ['-lc', `command -v ${binaryName} 2>/dev/null`], { encoding: 'utf-8', timeout: 2000 })
   const resolved = (probe.stdout || '').trim() || null
   binaryLookupCache.set(binaryName, { checkedAt: now, path: resolved })
   return resolved


### PR DESCRIPTION
## Summary

Three places hardcode `/bin/zsh` as the shell for spawning subprocesses:
- `process-manager.ts` → `getShellCommand()`
- `provider-health.ts` → `commandExists()`
- `session-tools/context.ts` → `resolveBinaryPath()`

This fails on Linux/WSL where zsh is not installed, producing:
```
[process] Spawn error: spawn /bin/zsh ENOENT
```

## Fix

Use `process.env.SHELL || '/bin/bash'` — respects the user's configured shell while falling back to bash (available on all Unix systems). Login shell mode (`-lc`) is preserved for proper PATH resolution.

## Test plan

- [x] Verified on WSL2 (Ubuntu, bash as default shell) — deploy and agent creation work
- [ ] macOS with zsh should continue working (SHELL=/bin/zsh)
- [ ] Linux with bash should now work (SHELL=/bin/bash)