### PR TITLE
fix: prevent daemon spawn failure when daemon runs in-process (dev mode)

### DIFF
--- a/src/lib/server/daemon/controller.ts
+++ b/src/lib/server/daemon/controller.ts
@@ -25,6 +25,7 @@ import type {
 } from '@/lib/server/daemon/types'
 import { DATA_DIR } from '@/lib/server/data-dir'
 import { loadEstopState } from '@/lib/server/runtime/estop'
+import { getDaemonStatus } from '@/lib/server/runtime/daemon-state/core'
 import { daemonAutostartEnvEnabled } from '@/lib/server/runtime/daemon-policy'
 import {
   releaseRuntimeLock,
@@ -344,6 +345,12 @@ export async function ensureDaemonProcessRunning(
   source: string,
   opts?: { manualStart?: boolean },
 ): Promise<boolean> {
+  // In dev mode, the daemon may already be running in-process (same Next.js server)
+  // without a daemon-admin.json file. Check in-process state first to avoid spawning
+  // a subprocess that fails to acquire the already-held lease.
+  const inProcessStatus = getDaemonStatus()
+  if (inProcessStatus.running) return false
+
   const manualStart = opts?.manualStart === true
   const record = loadDaemonStatusRecord()
   if (loadEstopState().level !== 'none') return false


### PR DESCRIPTION
## Problem

In dev mode (`npm run dev`), creating a second agent always fails with:

```
Error: Daemon process <pid> exited before becoming ready.
```

## Root Cause

In dev mode, the Next.js server process runs daemon logic **in-process** via `startDaemon()`, which acquires the `daemon-primary` runtime lock. However, `daemon-admin.json` is **not written** for in-process daemons.

When `ensureDaemonProcessRunning()` is called on agent creation:
1. It checks `daemon-admin.json` → not found
2. Thinks no daemon is running
3. Spawns a subprocess
4. Subprocess cannot acquire the lock (held by parent) → exits immediately
5. Controller throws: `Daemon process <pid> exited before becoming ready`

## Fix

Check `getDaemonStatus().running` (in-process memory flag) at the top of `ensureDaemonProcessRunning()`. If the daemon is already running in the current process, return early without spawning.

This only affects dev mode — production builds run the daemon as a separate process with proper admin metadata.

## Test plan

- [x] Dev mode: create first agent (daemon starts in-process) → create second agent → no error
- [ ] Production mode: daemon still spawns as separate process correctly