### PR TITLE
fix: break infinite render loop in GatewaySheet when gateway RPC fails

### DIFF
--- a/src/components/gateways/gateway-sheet.tsx
+++ b/src/components/gateways/gateway-sheet.tsx
@@ -118,11 +118,14 @@ export function GatewaySheet() {
     setInvokeParamsText('{}')
   }, [open, editing, gatewayProfiles.length])
 
+  const refreshRef = useRef(refreshGatewayTopologyMutation)
+  refreshRef.current = refreshGatewayTopologyMutation
+
   const loadNodesAndDevices = useCallback(async (profileId: string) => {
     setNodesLoading(true)
     setNodesError('')
     try {
-      const result = await refreshGatewayTopologyMutation.mutateAsync(profileId)
+      const result = await refreshRef.current.mutateAsync(profileId)
       setNodes(result.nodes)
       setNodePairings(result.nodePairings)
       setDevicePairings(result.devicePairings)
@@ -136,7 +139,7 @@ export function GatewaySheet() {
     } finally {
       setNodesLoading(false)
     }
-  }, [refreshGatewayTopologyMutation])
+  }, [])
 
   useEffect(() => {
     if (!open || !editing?.id) return


### PR DESCRIPTION
## Problem

Opening a gateway profile in the Providers page triggers an infinite render loop, crashing with:

```
Maximum update depth exceeded
```

The terminal shows hundreds of `POST /api/openclaw/gateway 502` requests per second.

## Root Cause

`loadNodesAndDevices` in `gateway-sheet.tsx` is wrapped in `useCallback` with `refreshGatewayTopologyMutation` as a dependency. React Query returns a **new mutation object reference** on every render, so:

1. `useCallback` deps change → new function reference
2. `useEffect` depends on `loadNodesAndDevices` → re-fires
3. Mutation runs 3 RPC calls → they fail (502/503) → component re-renders
4. Back to step 1 → infinite loop

## Fix

Store the mutation in a `useRef` and remove it from `useCallback` deps. The function reference is now stable across renders.

```diff
+ const refreshRef = useRef(refreshGatewayTopologyMutation)
+ refreshRef.current = refreshGatewayTopologyMutation

  const loadNodesAndDevices = useCallback(async (profileId: string) => {
-   const result = await refreshGatewayTopologyMutation.mutateAsync(profileId)
+   const result = await refreshRef.current.mutateAsync(profileId)
- }, [refreshGatewayTopologyMutation])
+ }, [])
```

## Test plan

- [x] Open gateway profile when gateway is disconnected → no crash, shows error message
- [x] Open gateway profile when gateway is connected → loads normally
- [ ] Verify topology refresh button still works after opening