### PR TITLE
fix: strip npm_config_prefix from subprocess env to fix nvm compatibility

### DIFF
--- a/src/lib/server/runtime/process-manager.ts
+++ b/src/lib/server/runtime/process-manager.ts
@@ -247,9 +247,12 @@ export async function startManagedProcess(opts: StartProcessOptions): Promise<St
   state.records.set(id, record)
 
   const { shell, args } = getShellCommand(opts.command, id, opts.sandbox)
-  // Strip SwarmClaw-specific env vars so agent child processes don't inherit
-  // our port binding or internal keys (e.g. npm dev servers defaulting to :3456)
-  const stripKeys = new Set(['PORT', 'ACCESS_KEY', 'NEXTAUTH_SECRET'])
+  // Strip env vars that should not leak into child processes:
+  // - PORT, ACCESS_KEY, NEXTAUTH_SECRET: SwarmClaw-specific bindings
+  // - npm_config_prefix: injected by npm when running scripts; conflicts with nvm
+  //   in login shell subprocesses (nvm refuses to initialize when this is set,
+  //   breaking node PATH resolution for all nvm users)
+  const stripKeys = new Set(['PORT', 'ACCESS_KEY', 'NEXTAUTH_SECRET', 'npm_config_prefix'])
   const cleanEnv = Object.fromEntries(Object.entries(process.env).filter(([k]) => !stripKeys.has(k))) as NodeJS.ProcessEnv
   const child = spawn(shell, args, {
     cwd: opts.sandbox ? undefined : opts.cwd,


### PR DESCRIPTION
## Problem

OpenClaw local deploy fails when SwarmClaw is started via `npm run dev`:

```
nvm is not compatible with the "npm_config_prefix" environment variable:
currently set to "/home/user/.nvm/versions/node/v25.1.0"
Run `unset npm_config_prefix` to unset it.
/usr/bin/env: 'node': No such file or directory
```

This affects **all users who manage Node.js via nvm** (the most common Node version manager).

## Root Cause

1. `npm run dev` automatically injects `npm_config_prefix` into `process.env` (standard npm behavior for all scripts)
2. `startManagedProcess()` passes `process.env` to child subprocesses (minus a few stripped keys)
3. Child subprocess starts with `bash -lc` (login shell)
4. Login shell initializes nvm, which detects `npm_config_prefix` and **refuses to load** (documented nvm safety check)
5. Without nvm, `node` is not in PATH → OpenClaw binary fails

## Fix

Add `npm_config_prefix` to the existing `stripKeys` set in `startManagedProcess()`. This set already strips `PORT`, `ACCESS_KEY`, and `NEXTAUTH_SECRET` for the same reason — parent process env vars that break child process behavior.

```diff
- const stripKeys = new Set(['PORT', 'ACCESS_KEY', 'NEXTAUTH_SECRET'])
+ const stripKeys = new Set(['PORT', 'ACCESS_KEY', 'NEXTAUTH_SECRET', 'npm_config_prefix'])
```

## Why this is a code fix, not an environment issue

- npm **always** sets `npm_config_prefix` when running scripts — users cannot prevent it
- nvm **always** refuses to init when `npm_config_prefix` is set — this is by design
- `npm run dev` is the documented way to start SwarmClaw
- Therefore: every nvm user hits this bug. It's not edge-case.

## Test plan

- [x] WSL2 + nvm + `npm run dev` → Deploy on this host → OpenClaw starts successfully
- [ ] macOS + nvm + `npm run dev` → same flow should work
- [ ] Systems without nvm → no behavior change (variable simply absent from env)