### PR TITLE
fix: support custom base URL for built-in providers and add test model selector

### DIFF
--- a/src/app/api/providers/[id]/route.ts
+++ b/src/app/api/providers/[id]/route.ts
@@ -31,7 +31,7 @@ export async function PUT(req: Request, { params }: { params: Promise<{ id: stri
       id,
       name: builtin.name,
       type: 'builtin',
-      baseUrl: builtin.defaultEndpoint || '',
+      baseUrl: (typeof body.baseUrl === 'string' ? body.baseUrl : builtin.defaultEndpoint) || '',
       models: [...builtin.models],
       requiresApiKey: builtin.requiresApiKey,
       credentialId: null,

--- a/src/app/api/setup/check-provider/route.ts
+++ b/src/app/api/setup/check-provider/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
-import { loadCredentials, decryptKey } from '@/lib/server/storage'
+import { loadCredentials, decryptKey, loadProviderConfigs } from '@/lib/server/storage'
+import { listCredentialIdsByProvider } from '@/lib/server/credentials/credential-service'
 import { getDeviceId, wsConnect, rpcOnConnectedGateway } from '@/lib/providers/openclaw'
 import { buildCliEnv, probeCliAuth, resolveCliBinary } from '@/lib/providers/cli-utils'
 import { OPENAI_COMPATIBLE_DEFAULTS } from '@/lib/server/provider-health'
@@ -109,7 +110,7 @@ async function checkOpenAiCompatible(
     },
     body: JSON.stringify({
       model: testModel,
-      max_tokens: 8,
+      max_completion_tokens: 8,
       messages: [{ role: 'user', content: 'Reply OK' }],
     }),
     signal: AbortSignal.timeout(15_000),
@@ -126,9 +127,10 @@ async function checkOpenAiCompatible(
   }
 }
 
-async function checkAnthropic(apiKey: string, modelRaw: string): Promise<{ ok: boolean; message: string }> {
+async function checkAnthropic(apiKey: string, endpointRaw: string, modelRaw: string): Promise<{ ok: boolean; message: string }> {
   const model = modelRaw || 'claude-sonnet-4-6'
-  const res = await fetch('https://api.anthropic.com/v1/messages', {
+  const baseUrl = (endpointRaw || 'https://api.anthropic.com').replace(/\/+$/, '')
+  const res = await fetch(`${baseUrl}/v1/messages`, {
     method: 'POST',
     headers: {
       'x-api-key': apiKey,
@@ -221,7 +223,7 @@ async function checkOllama(params: {
   // Test the chat endpoint
   const label = runtime.useCloud ? 'Ollama Cloud' : 'Ollama'
   const chatEndpoint = `${normalizedEndpoint}/v1/chat/completions`
-  const chatBody = JSON.stringify({ model: testModel, max_tokens: 8, messages: [{ role: 'user', content: 'Reply OK' }] })
+  const chatBody = JSON.stringify({ model: testModel, max_completion_tokens: 8, messages: [{ role: 'user', content: 'Reply OK' }] })
 
   const chatRes = await fetch(chatEndpoint, {
     method: 'POST',
@@ -312,7 +314,7 @@ export async function POST(req: Request) {
   const provider = clean(body.provider) as SetupProvider
   let apiKey = clean(body.apiKey)
   const credentialId = clean(body.credentialId)
-  const endpoint = clean(body.endpoint)
+  let endpoint = clean(body.endpoint)
   const model = clean(body.model)
   const CLI_PROVIDERS = new Set<CliSetupProvider>(['claude-cli', 'codex-cli', 'opencode-cli', 'gemini-cli', 'copilot-cli', 'droid-cli', 'cursor-cli', 'qwen-code-cli', 'goose'])
 
@@ -327,6 +329,30 @@ export async function POST(req: Request) {
     } catch {
       return NextResponse.json({ ok: false, message: 'Failed to decrypt credential.' }, { status: 500 })
     }
+  }
+
+  // Auto-resolve credential by provider when no explicit credentialId
+  if (!apiKey && !credentialId && provider) {
+    try {
+      const credIds = listCredentialIdsByProvider(provider)
+      if (credIds.length > 0) {
+        const creds = loadCredentials()
+        for (const cid of credIds) {
+          if (creds[cid]?.encryptedKey) {
+            try { apiKey = decryptKey(creds[cid].encryptedKey); break } catch { /* skip */ }
+          }
+        }
+      }
+    } catch { /* best effort */ }
+  }
+
+  // Auto-resolve endpoint from provider config when not explicitly provided
+  if (!endpoint && provider) {
+    try {
+      const pConfigs = loadProviderConfigs()
+      const pConfig = pConfigs[provider]
+      if (pConfig?.baseUrl) endpoint = pConfig.baseUrl
+    } catch { /* best effort */ }
   }
 
   if (CLI_PROVIDERS.has(provider as CliSetupProvider)) {
@@ -354,7 +380,7 @@ export async function POST(req: Request) {
       }
       case 'anthropic': {
         if (!apiKey) return NextResponse.json({ ok: false, message: 'Anthropic API key is required.' })
-        const result = await checkAnthropic(apiKey, model)
+        const result = await checkAnthropic(apiKey, endpoint, model)
         return NextResponse.json(result)
       }
       case 'google':

--- a/src/components/agents/agent-sheet.tsx
+++ b/src/components/agents/agent-sheet.tsx
@@ -1656,7 +1656,7 @@ export function AgentSheet() {
         </div>
       )}
 
-      {currentProvider?.requiresEndpoint && (provider !== 'ollama' || ollamaMode === 'local') && (
+      {(currentProvider?.requiresEndpoint || currentProvider?.optionalEndpoint) && (provider !== 'ollama' || ollamaMode === 'local') && (
         <div className="mb-8">
           <SectionLabel>{provider === 'openclaw' ? 'OpenClaw Endpoint' : provider === 'hermes' ? 'Hermes API Endpoint' : 'Endpoint'}</SectionLabel>
           <input type="text" value={apiEndpoint || ''} onChange={(e) => setApiEndpoint(e.target.value || null)} placeholder={currentProvider.defaultEndpoint || 'http://localhost:11434'} className={`${inputClass} font-mono text-[14px]`} />

--- a/src/components/providers/provider-sheet.tsx
+++ b/src/components/providers/provider-sheet.tsx
@@ -53,6 +53,7 @@ export function ProviderSheet() {
   // Test connection state
   const [testStatus, setTestStatus] = useState<'idle' | 'testing' | 'pass' | 'fail'>('idle')
   const [testMessage, setTestMessage] = useState('')
+  const [testModel, setTestModel] = useState('')
 
   const [liveModels, setLiveModels] = useState<string[]>([])
   const [liveLoading, setLiveLoading] = useState(false)
@@ -85,7 +86,7 @@ export function ProviderSheet() {
         setIsEnabled(editingCustom.isEnabled)
       } else if (editingBuiltin) {
         setName(editingBuiltin.name)
-        setBaseUrl(editingBuiltin.defaultEndpoint || '')
+        setBaseUrl(editingBuiltinOverride?.baseUrl || editingBuiltin.defaultEndpoint || '')
         setModels(editingBuiltin.models.join(', '))
         setRequiresApiKey(editingBuiltin.requiresApiKey)
         // Default to existing credential for this provider
@@ -113,6 +114,7 @@ export function ProviderSheet() {
     setLiveModels([])
     setLiveMessage('')
     setLiveCached(false)
+    setTestModel('')
   }, [editingId, credentialId, baseUrl, requiresApiKey])
 
   const handleTestConnection = async () => {
@@ -124,6 +126,7 @@ export function ProviderSheet() {
         provider: editingId || 'custom',
         credentialId,
         endpoint: baseUrl,
+        model: testModel || undefined,
       })
       if (result.ok) {
         setTestStatus('pass')
@@ -157,6 +160,7 @@ export function ProviderSheet() {
           id: editingId || '',
           models: modelList,
           isEnabled,
+          baseUrl: baseUrl.trim() || undefined,
         })
         toast.success('Built-in provider updated')
         onClose()
@@ -290,7 +294,7 @@ export function ProviderSheet() {
       </div>
 
       {/* Base URL — for custom providers and built-ins with endpoints (Ollama, OpenClaw) */}
-      {(!isBuiltin || editingBuiltin?.requiresEndpoint) && (
+      {(!isBuiltin || editingBuiltin?.requiresEndpoint || editingBuiltin?.optionalEndpoint) && (
         <div className="mb-8">
           <label className="block font-display text-[12px] font-600 text-text-2 uppercase tracking-[0.08em] mb-3">
             {isBuiltin ? 'Endpoint' : 'Base URL'}
@@ -511,6 +515,27 @@ export function ProviderSheet() {
               <span className="text-[12px] text-text-3">Hidden from the agent sheet when off.</span>
             )}
           </label>
+        </div>
+      )}
+
+      {/* Test model selector */}
+      {showTestButton && (
+        <div className="mb-4">
+          <label className="block font-display text-[12px] font-600 text-text-2 uppercase tracking-[0.08em] mb-3">
+            Test Model
+            <span className="normal-case tracking-normal font-normal text-text-3 ml-1">(optional)</span>
+          </label>
+          <select
+            value={testModel}
+            onChange={(e) => { setTestModel(e.target.value); setTestStatus('idle'); setTestMessage('') }}
+            className={`${inputClass} appearance-none cursor-pointer`}
+            style={{ fontFamily: 'inherit' }}
+          >
+            <option value="">Auto-detect</option>
+            {modelList.map((m) => (
+              <option key={m} value={m}>{m}</option>
+            ))}
+          </select>
         </div>
       )}
 

--- a/src/features/providers/queries.ts
+++ b/src/features/providers/queries.ts
@@ -25,6 +25,7 @@ interface SaveBuiltinProviderInput {
   id: string
   models: string[]
   isEnabled: boolean
+  baseUrl?: string
 }
 
 interface SaveCustomProviderInput {
@@ -36,6 +37,7 @@ interface CheckProviderConnectionInput {
   provider: string
   credentialId?: string | null
   endpoint?: string | null
+  model?: string | null
 }
 
 async function invalidateProviderQueries(queryClient: ReturnType<typeof useQueryClient>) {
@@ -80,11 +82,12 @@ export function useToggleProviderMutation() {
 export function useSaveBuiltinProviderMutation() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: async ({ id, models, isEnabled }: SaveBuiltinProviderInput) => {
+    mutationFn: async ({ id, models, isEnabled, baseUrl }: SaveBuiltinProviderInput) => {
       await api('PUT', `/providers/${id}/models`, { models })
       return api('PUT', `/providers/${id}`, {
         type: 'builtin',
         isEnabled,
+        ...(baseUrl ? { baseUrl } : {}),
       })
     },
     onSuccess: async () => {
@@ -126,11 +129,12 @@ export function useResetProviderModelsMutation() {
 
 export function useCheckProviderConnectionMutation() {
   return useMutation({
-    mutationFn: ({ provider, credentialId, endpoint }: CheckProviderConnectionInput) =>
+    mutationFn: ({ provider, credentialId, endpoint, model }: CheckProviderConnectionInput) =>
       api<{ ok: boolean; message: string }>('POST', '/setup/check-provider', {
         provider,
         credentialId,
         endpoint,
+        model,
       }),
   })
 }

--- a/src/lib/providers/anthropic.ts
+++ b/src/lib/providers/anthropic.ts
@@ -1,5 +1,4 @@
 import fs from 'fs'
-import https from 'https'
 import type { StreamChatOptions } from './index'
 import { PROVIDER_DEFAULTS, IMAGE_EXTS, TEXT_EXTS, ANTHROPIC_MAX_TOKENS, MAX_HISTORY_MESSAGES, writeSSE } from './provider-defaults'
 import { log } from '@/lib/server/logger'
@@ -45,55 +44,66 @@ export function streamAnthropicChat({ session, message, imagePath, apiKey, syste
         }
 
         const payload = JSON.stringify(body)
-        const abortController = { aborted: false }
-        let fullResponse = ''
-        let apiReqRef: ReturnType<typeof https.request> | null = null
 
+        // Support custom base URL (e.g. proxy / gateway)
+        const baseUrl = (session.apiEndpoint || PROVIDER_DEFAULTS.anthropic).replace(/\/+$/, '')
+        const url = `${baseUrl}/v1/messages`
+
+        const abortController = new AbortController()
         if (signal) {
-          if (signal.aborted) {
-            abortController.aborted = true
-          } else {
-            signal.addEventListener('abort', () => {
-              abortController.aborted = true
-              apiReqRef?.destroy()
-            }, { once: true })
-          }
+          if (signal.aborted) abortController.abort()
+          else signal.addEventListener('abort', () => abortController.abort(), { once: true })
         }
+        active.set(session.id, { kill: () => abortController.abort() })
 
-        const apiReq = https.request({
-          hostname: PROVIDER_DEFAULTS.anthropic,
-          path: '/v1/messages',
-          method: 'POST',
-          timeout: 60_000,
-          headers: {
-            'x-api-key': apiKey || '',
-            'anthropic-version': '2023-06-01',
-            'Content-Type': 'application/json',
-          },
-        }, (apiRes) => {
-          if (apiRes.statusCode !== 200) {
-            let errBody = ''
-            apiRes.on('data', (c: Buffer) => errBody += c)
-            apiRes.on('end', () => {
-              const msg = `Anthropic error ${apiRes.statusCode}: ${errBody.slice(0, 200)}`
-              log.error(TAG, `[${session.id}] ${msg}`)
-              let errMsg = `Anthropic API error (${apiRes.statusCode})`
-              try {
-                const parsed = JSON.parse(errBody)
-                if (parsed.error?.message) errMsg = parsed.error.message
-              } catch {}
-              writeSSE(write, 'err', errMsg)
-              active.delete(session.id)
-              reject(new Error(msg))
-            })
+        let fullResponse = ''
+
+        try {
+          const res = await fetch(url, {
+            method: 'POST',
+            headers: {
+              'x-api-key': apiKey || '',
+              'anthropic-version': '2023-06-01',
+              'Content-Type': 'application/json',
+            },
+            body: payload,
+            signal: abortController.signal,
+          })
+
+          if (!res.ok) {
+            const errBody = await res.text().catch(() => '')
+            const msg = `Anthropic error ${res.status}: ${errBody.slice(0, 200)}`
+            log.error(TAG, `[${session.id}] ${msg}`)
+            let errMsg = `Anthropic API error (${res.status})`
+            try {
+              const parsed = JSON.parse(errBody)
+              if (parsed.error?.message) errMsg = parsed.error.message
+            } catch {}
+            writeSSE(write, 'err', errMsg)
+            active.delete(session.id)
+            reject(new Error(msg))
             return
           }
 
+          if (!res.body) {
+            const msg = `No response body from ${baseUrl}`
+            log.error(TAG, `[${session.id}] ${msg}`)
+            active.delete(session.id)
+            reject(new Error(msg))
+            return
+          }
+
+          const reader = res.body.getReader()
+          const decoder = new TextDecoder()
           let buf = ''
           let malformedChunkLogged = false
-          apiRes.on('data', (chunk: Buffer) => {
-            if (abortController.aborted) return
-            buf += chunk.toString()
+
+          while (true) {
+            const { done, value } = await reader.read()
+            if (done) break
+            if (abortController.signal.aborted) break
+
+            buf += decoder.decode(value, { stream: true })
             const lines = buf.split('\n')
             buf = lines.pop()!
 
@@ -122,33 +132,21 @@ export function streamAnthropicChat({ session, message, imagePath, apiKey, syste
                 }
               }
             }
-          })
+          }
 
-          apiRes.on('end', () => {
-            if (onUsage && (usageInput > 0 || usageOutput > 0)) {
-              onUsage({ inputTokens: usageInput, outputTokens: usageOutput })
-            }
-            active.delete(session.id)
-            resolve(fullResponse)
-          })
-        })
+          if (onUsage && (usageInput > 0 || usageOutput > 0)) {
+            onUsage({ inputTokens: usageInput, outputTokens: usageOutput })
+          }
+        } catch (err: unknown) {
+          const errObj = err as { name?: string; message?: string }
+          if (errObj.name !== 'AbortError') {
+            log.error(TAG, `[${session.id}] anthropic fetch error:`, errObj.message || '')
+            writeSSE(write, 'err', errObj.message || 'Anthropic request failed')
+          }
+        }
 
-        apiReqRef = apiReq
-        active.set(session.id, { kill: () => { abortController.aborted = true; apiReq.destroy() } })
-
-        apiReq.on('timeout', () => {
-          log.error(TAG, `[${session.id}] anthropic request timed out after 60s`)
-          apiReq.destroy(new Error('Request timed out after 60s'))
-        })
-
-        apiReq.on('error', (e) => {
-          log.error(TAG, `[${session.id}] anthropic request error:`, e.message)
-          writeSSE(write, 'err', e.message)
-          active.delete(session.id)
-          reject(e)
-        })
-
-        apiReq.end(payload)
+        active.delete(session.id)
+        resolve(fullResponse)
       } catch (err) { reject(err) }
     })()
   })

--- a/src/lib/providers/index.ts
+++ b/src/lib/providers/index.ts
@@ -74,6 +74,8 @@ export const PROVIDERS: Record<string, BuiltinProviderConfig> = {
     models: ['gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-nano', 'gpt-5.3', 'o3-mini', 'gpt-4.1', 'gpt-4.1-mini'],
     requiresApiKey: true,
     requiresEndpoint: false,
+    optionalEndpoint: true,
+    defaultEndpoint: 'https://api.openai.com/v1',
     handler: { streamChat: streamOpenAiChat },
   },
   openrouter: {
@@ -107,7 +109,17 @@ export const PROVIDERS: Record<string, BuiltinProviderConfig> = {
     models: ['claude-opus-4-6', 'claude-sonnet-4-6', 'claude-haiku-4-5'],
     requiresApiKey: true,
     requiresEndpoint: false,
-    handler: { streamChat: streamAnthropicChat },
+    optionalEndpoint: true,
+    defaultEndpoint: 'https://api.anthropic.com',
+    handler: {
+      streamChat: (opts) => {
+        const patchedSession = {
+          ...opts.session,
+          apiEndpoint: opts.session.apiEndpoint || 'https://api.anthropic.com',
+        }
+        return streamAnthropicChat({ ...opts, session: patchedSession })
+      },
+    },
   },
   openclaw: {
     id: 'openclaw',
@@ -518,7 +530,28 @@ function buildCustomProviderConfig(custom: CustomProviderConfig): BuiltinProvide
 }
 
 export function getProvider(id: string): BuiltinProviderConfig | null {
-  if (PROVIDERS[id]) return PROVIDERS[id]
+  // Check builtin providers — inject custom baseUrl from provider config if set
+  const builtin = PROVIDERS[id]
+  if (builtin) {
+    const pConfigs = loadProviderConfigs()
+    const pConfig = pConfigs[id]
+    if (pConfig?.baseUrl && pConfig.baseUrl !== builtin.defaultEndpoint) {
+      const originalHandler = builtin.handler
+      return {
+        ...builtin,
+        handler: {
+          streamChat: (opts) => {
+            const patchedSession = {
+              ...opts.session,
+              apiEndpoint: opts.session.apiEndpoint || pConfig.baseUrl,
+            }
+            return originalHandler.streamChat({ ...opts, session: patchedSession })
+          },
+        },
+      }
+    }
+    return builtin
+  }
 
   // Check custom providers
   const customs = getCustomProviders()

--- a/src/lib/providers/provider-defaults.ts
+++ b/src/lib/providers/provider-defaults.ts
@@ -1,7 +1,7 @@
 /** Default base URLs for built-in LLM providers */
 export const PROVIDER_DEFAULTS = {
   openai: 'https://api.openai.com/v1',
-  anthropic: 'api.anthropic.com',
+  anthropic: 'https://api.anthropic.com',
   ollama: 'http://localhost:11434',
   ollamaCloud: 'https://ollama.com',
 } as const

--- a/src/lib/server/build-llm.ts
+++ b/src/lib/server/build-llm.ts
@@ -79,6 +79,7 @@ export function buildChatModel(opts: {
     const anthropicOpts: Record<string, unknown> = {
       model: model || 'claude-sonnet-4-6',
       anthropicApiKey: resolvedApiKey || undefined,
+      ...(endpoint ? { anthropicApiUrl: endpoint } : {}),
       maxTokens: 8192,
       maxRetries: OPENAI_COMPAT_MODEL_MAX_RETRIES,
     }

--- a/src/lib/server/provider-endpoint.ts
+++ b/src/lib/server/provider-endpoint.ts
@@ -3,6 +3,7 @@ import { getProvider } from '@/lib/providers'
 import { loadCredential } from '@/lib/server/credentials/credential-repository'
 import { listCredentialIdsByProvider, resolveCredentialSecret } from '@/lib/server/credentials/credential-service'
 import { resolveOllamaRuntimeConfig } from '@/lib/server/ollama-runtime'
+import { loadProviderConfigs } from '@/lib/server/storage'
 
 function clean(value: string | null | undefined): string | null {
   if (typeof value !== 'string') return null
@@ -16,7 +17,23 @@ export function resolveProviderCredentialId(input: {
   credentialId?: string | null
 }): string | null {
   const normalizedId = clean(input.credentialId)
-  if (!normalizedId) return null
+
+  // When no credentialId provided, auto-match by provider
+  if (!normalizedId) {
+    const provider = clean(input.provider)
+    if (!provider) return null
+    const byProvider = listCredentialIdsByProvider(provider)
+      .map((id) => [id, loadCredential(id)] as const)
+      .filter(([, cred]) => Boolean(cred))
+    if (byProvider.length === 1) return byProvider[0][0]
+    if (byProvider.length > 1) {
+      // Pick the most recently created credential
+      return [...byProvider]
+        .sort((a, b) => ((b[1]?.createdAt as number) || 0) - ((a[1]?.createdAt as number) || 0))[0]?.[0] || null
+    }
+    return null
+  }
+
   if (loadCredential(normalizedId)) return normalizedId
 
   const provider = clean(input.provider)
@@ -69,6 +86,15 @@ export function resolveProviderApiEndpoint(input: {
       apiEndpoint: null,
     })
     return normalizeProviderEndpoint(provider, runtime.endpoint) || runtime.endpoint.replace(/\/+$/, '')
+  }
+
+  // Prefer provider config's custom baseUrl over the hardcoded defaultEndpoint
+  const pConfigs = loadProviderConfigs()
+  const pConfig = pConfigs[provider]
+  if (pConfig?.baseUrl) {
+    const customNormalized = normalizeProviderEndpoint(provider, pConfig.baseUrl)
+    if (customNormalized) return customNormalized
+    return pConfig.baseUrl.replace(/\/+$/, '')
   }
 
   const providerInfo = getProvider(provider)

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -10,6 +10,8 @@ export interface ProviderInfo {
   requiresApiKey: boolean
   optionalApiKey?: boolean
   requiresEndpoint: boolean
+  /** When true, shows an optional Base URL field in provider settings (e.g. for proxies). */
+  optionalEndpoint?: boolean
   defaultEndpoint?: string
 }
 


### PR DESCRIPTION
## Problem

Built-in providers (OpenAI, Anthropic, etc.) do not properly persist or resolve custom base URLs when users configure third-party proxies or self-hosted endpoints. The provider connection test also lacks the ability to select a specific model for verification.

### Root causes

1. provider-sheet.tsx — handleSave() did not pass baseUrl for built-in providers
2. provider-endpoint.ts — No auto-resolution of credentials by provider; ignored stored baseUrl
3. check-provider/route.ts — Hardcoded Anthropic URL; no auto-resolve in POST handler; used deprecated max_tokens
4. build-llm.ts — ChatAnthropic never received anthropicApiUrl
5. agent-sheet.tsx — Base URL input hidden for optionalEndpoint providers
6. queries.ts — No model field in connection test input

## Fix

- **Credential auto-resolution**: match by provider when no explicit credentialId
- **Endpoint auto-resolution**: read provider config baseUrl before falling back to defaults
- **Anthropic**: dynamic URL in test + anthropicApiUrl in LangGraph path + fetch() refactor
- **Provider settings UI**: pass baseUrl on save; add test model selector dropdown
- **Agent editor**: show Base URL input for optionalEndpoint providers
- **OpenAI-compatible test**: use max_completion_tokens instead of max_tokens
- **Provider PUT handler**: respect body.baseUrl on first-time builtin override creation

## Verification

- Save custom base URL for OpenAI/Anthropic → persisted and auto-resolved on test
- Credential auto-resolution with zero explicit params finds correct credential
- Model selector works for specific models (e.g. gpt-4.1-mini, claude-haiku-4-5)
- Auto-detect falls back to model discovery / provider defaults
- LangGraph ChatAnthropic receives custom endpoint
- No breaking changes when no custom base URL is configured

## Files changed (11 files, +198 -83)

| File | Change |
|------|--------|
| src/lib/server/provider-endpoint.ts | Auto-resolve credential + read provider config baseUrl |
| src/app/api/setup/check-provider/route.ts | Dynamic Anthropic URL; POST auto-resolve; max_completion_tokens |
| src/lib/server/build-llm.ts | Pass anthropicApiUrl to ChatAnthropic |
| src/components/providers/provider-sheet.tsx | Pass baseUrl on save; add test model selector |
| src/features/providers/queries.ts | Add model to connection test input and mutation |
| src/components/agents/agent-sheet.tsx | Show Base URL for optionalEndpoint providers |
| src/lib/providers/anthropic.ts | Refactor to fetch() for custom base URL support |
| src/lib/providers/index.ts | Register optionalEndpoint; inject baseUrl from config |
| src/lib/providers/provider-defaults.ts | Update Anthropic default endpoint |
| src/types/provider.ts | Add optionalEndpoint to ProviderInfo |
| src/app/api/providers/[id]/route.ts | Respect body.baseUrl on first-time override |