### PR TITLE
feat: add Exa AI-powered search tool

### DIFF
--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -26,7 +26,7 @@ const TASK_QG_MIN_EVIDENCE_MIN = 0
 const TASK_QG_MIN_EVIDENCE_MAX = 8
 const SESSION_RESET_TIMEOUT_MIN = 0
 const SESSION_RESET_TIMEOUT_MAX = 365 * 24 * 60 * 60
-const SECRET_SETTING_KEYS = ['elevenLabsApiKey', 'tavilyApiKey', 'braveApiKey'] as const
+const SECRET_SETTING_KEYS = ['elevenLabsApiKey', 'tavilyApiKey', 'braveApiKey', 'exaApiKey'] as const
 
 function parseIntSetting(value: unknown, fallback: number, min: number, max: number): number {
   const parsed = typeof value === 'number'

--- a/src/lib/server/session-tools/search-providers.test.ts
+++ b/src/lib/server/session-tools/search-providers.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, beforeEach, afterEach, mock } from 'node:test'
+import assert from 'node:assert/strict'
+
+describe('getSearchProvider — exa', () => {
+  const originalEnv = process.env.EXA_API_KEY
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.EXA_API_KEY
+    else process.env.EXA_API_KEY = originalEnv
+  })
+
+  it('throws when no API key is available', async () => {
+    delete process.env.EXA_API_KEY
+    const { getSearchProvider } = await import('./search-providers')
+    await assert.rejects(
+      () => getSearchProvider({ webSearchProvider: 'exa' }),
+      (err: Error) => {
+        assert.match(err.message, /Exa requires an API key/)
+        return true
+      },
+    )
+  })
+
+  it('resolves an ExaProvider from EXA_API_KEY env var', async () => {
+    process.env.EXA_API_KEY = 'test-key-123'
+    const { getSearchProvider } = await import('./search-providers')
+    const provider = await getSearchProvider({ webSearchProvider: 'exa' })
+    assert.equal(provider.id, 'exa')
+    assert.equal(provider.name, 'Exa')
+  })
+
+  it('prefers settings key over env var', async () => {
+    process.env.EXA_API_KEY = 'env-key'
+    const { getSearchProvider } = await import('./search-providers')
+    const provider = await getSearchProvider({ webSearchProvider: 'exa', exaApiKey: 'settings-key' })
+    assert.equal(provider.id, 'exa')
+  })
+})
+
+describe('ExaProvider.search — response parsing', () => {
+  const FIXTURE = {
+    requestId: 'test-req-1',
+    results: [
+      {
+        title: 'Exa AI Search',
+        url: 'https://exa.ai',
+        publishedDate: '2024-01-15',
+        author: 'Exa Team',
+        text: 'Exa is a search engine for AI.',
+        highlights: ['Exa provides neural search.', 'Built for developers.'],
+        highlightScores: [0.95, 0.88],
+        summary: 'Exa is an AI-powered search engine built for developers.',
+      },
+      {
+        title: 'Getting Started with Exa',
+        url: 'https://docs.exa.ai/getting-started',
+        text: 'Learn how to integrate Exa into your application.',
+        highlights: [],
+        summary: '',
+      },
+      {
+        title: 'Minimal Result',
+        url: 'https://example.com/minimal',
+      },
+    ],
+  }
+
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('parses a full API response into SearchResult[]', async () => {
+    globalThis.fetch = mock.fn(async () => new Response(JSON.stringify(FIXTURE), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })) as unknown as typeof globalThis.fetch
+
+    process.env.EXA_API_KEY = 'test-key'
+    const { getSearchProvider } = await import('./search-providers')
+    const provider = await getSearchProvider({ webSearchProvider: 'exa' })
+    const results = await provider.search('exa search', 10)
+
+    assert.equal(results.length, 3)
+    assert.equal(results[0].title, 'Exa AI Search')
+    assert.equal(results[0].url, 'https://exa.ai')
+    // Summary is preferred when available
+    assert.equal(results[0].snippet, 'Exa is an AI-powered search engine built for developers.')
+  })
+
+  it('falls back to text when summary and highlights are empty', async () => {
+    globalThis.fetch = mock.fn(async () => new Response(JSON.stringify(FIXTURE), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })) as unknown as typeof globalThis.fetch
+
+    process.env.EXA_API_KEY = 'test-key'
+    const { getSearchProvider } = await import('./search-providers')
+    const provider = await getSearchProvider({ webSearchProvider: 'exa' })
+    const results = await provider.search('exa search', 10)
+
+    // Second result has empty summary and empty highlights, should fall back to text
+    assert.equal(results[1].snippet, 'Learn how to integrate Exa into your application.')
+  })
+
+  it('returns empty snippet when no content fields are present', async () => {
+    globalThis.fetch = mock.fn(async () => new Response(JSON.stringify(FIXTURE), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })) as unknown as typeof globalThis.fetch
+
+    process.env.EXA_API_KEY = 'test-key'
+    const { getSearchProvider } = await import('./search-providers')
+    const provider = await getSearchProvider({ webSearchProvider: 'exa' })
+    const results = await provider.search('exa search', 10)
+
+    // Third result has no summary, no highlights, no text
+    assert.equal(results[2].snippet, '')
+    assert.equal(results[2].title, 'Minimal Result')
+  })
+
+  it('sends the integration tracking header', async () => {
+    let capturedHeaders: Record<string, string> = {}
+    globalThis.fetch = mock.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const headers = init?.headers as Record<string, string> | undefined
+      if (headers) capturedHeaders = { ...headers }
+      return new Response(JSON.stringify({ results: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }) as unknown as typeof globalThis.fetch
+
+    process.env.EXA_API_KEY = 'test-key'
+    const { getSearchProvider } = await import('./search-providers')
+    const provider = await getSearchProvider({ webSearchProvider: 'exa' })
+    await provider.search('test', 5)
+
+    assert.equal(capturedHeaders['x-exa-integration'], 'swarmclaw')
+    assert.equal(capturedHeaders['x-api-key'], 'test-key')
+  })
+
+  it('throws on non-OK HTTP response', async () => {
+    globalThis.fetch = mock.fn(async () => new Response('Unauthorized', {
+      status: 401,
+      statusText: 'Unauthorized',
+    })) as unknown as typeof globalThis.fetch
+
+    process.env.EXA_API_KEY = 'bad-key'
+    const { getSearchProvider } = await import('./search-providers')
+    const provider = await getSearchProvider({ webSearchProvider: 'exa' })
+
+    await assert.rejects(
+      () => provider.search('test', 5),
+      (err: Error) => {
+        assert.match(err.message, /401/)
+        return true
+      },
+    )
+  })
+})

--- a/src/lib/server/session-tools/search-providers.ts
+++ b/src/lib/server/session-tools/search-providers.ts
@@ -244,6 +244,65 @@ class BraveProvider implements WebSearchProvider {
 }
 
 // ---------------------------------------------------------------------------
+// Exa (API key required — from secrets or EXA_API_KEY env var)
+// ---------------------------------------------------------------------------
+
+interface ExaSearchResult {
+  title?: string
+  url?: string
+  publishedDate?: string | null
+  author?: string | null
+  text?: string
+  highlights?: string[]
+  highlightScores?: number[]
+  summary?: string
+}
+
+class ExaProvider implements WebSearchProvider {
+  id = 'exa'
+  name = 'Exa'
+
+  constructor(private apiKey: string) {}
+
+  async search(query: string, maxResults: number): Promise<SearchResult[]> {
+    const res = await fetch('https://api.exa.ai/search', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': this.apiKey,
+        'x-exa-integration': 'swarmclaw',
+      },
+      body: JSON.stringify({
+        query,
+        type: 'auto',
+        numResults: maxResults,
+        contents: {
+          highlights: { numSentences: 3 },
+          text: { maxCharacters: 500 },
+          summary: true,
+        },
+      }),
+      signal: AbortSignal.timeout(15000),
+    })
+    if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`)
+    const data = await res.json()
+    const rawResults: ExaSearchResult[] = Array.isArray(data.results) ? data.results : []
+    return rawResults.slice(0, maxResults).map((r) => ({
+      title: r.title || '',
+      url: r.url || '',
+      snippet: buildExaSnippet(r),
+    }))
+  }
+}
+
+function buildExaSnippet(result: ExaSearchResult): string {
+  if (result.summary) return result.summary
+  if (result.highlights && result.highlights.length > 0) return result.highlights.join(' … ')
+  if (result.text) return result.text
+  return ''
+}
+
+// ---------------------------------------------------------------------------
 // Factory
 // ---------------------------------------------------------------------------
 
@@ -278,6 +337,17 @@ export async function getSearchProvider(settings: Partial<AppSettings>): Promise
       }
       if (!apiKey) throw new Error('Brave Search requires an API key. Set one in Settings > Web Search.')
       return new BraveProvider(apiKey)
+    }
+    case 'exa': {
+      let apiKey = settings.exaApiKey
+      if (!apiKey) apiKey = process.env.EXA_API_KEY ?? null
+      if (!apiKey) {
+        const { getSecret } = await import('../storage')
+        const secret = await getSecret('exa')
+        apiKey = secret?.value ?? null
+      }
+      if (!apiKey) throw new Error('Exa requires an API key. Set one in Settings > Web Search or set the EXA_API_KEY environment variable.')
+      return new ExaProvider(apiKey)
     }
     default:
       return new DuckDuckGoProvider()

--- a/src/types/app-settings.ts
+++ b/src/types/app-settings.ts
@@ -115,8 +115,10 @@ export interface AppSettings {
   // Theme
   themeHue?: string
   // Web search provider
-  webSearchProvider?: 'duckduckgo' | 'google' | 'bing' | 'searxng' | 'tavily' | 'brave'
+  webSearchProvider?: 'duckduckgo' | 'google' | 'bing' | 'searxng' | 'tavily' | 'brave' | 'exa'
   searxngUrl?: string
+  exaApiKey?: string | null
+  exaApiKeyConfigured?: boolean
   // Task custom field definitions
   taskCustomFieldDefs?: Array<{ key: string; label: string; type: 'text' | 'number' | 'select'; options?: string[] }>
   // OpenClaw sync settings

--- a/src/views/settings/section-web-search.tsx
+++ b/src/views/settings/section-web-search.tsx
@@ -6,6 +6,7 @@ export function WebSearchSection({ appSettings, patchSettings, inputClass }: Set
   const provider = appSettings.webSearchProvider || 'duckduckgo'
   const hasTavilyKey = appSettings.tavilyApiKeyConfigured === true
   const hasBraveKey = appSettings.braveApiKeyConfigured === true
+  const hasExaKey = appSettings.exaApiKeyConfigured === true
 
   return (
     <div className="mb-10">
@@ -30,6 +31,7 @@ export function WebSearchSection({ appSettings, patchSettings, inputClass }: Set
             <option value="searxng">SearXNG (self-hosted, no key required)</option>
             <option value="tavily">Tavily (API key required)</option>
             <option value="brave">Brave Search (API key required)</option>
+            <option value="exa">Exa (API key required)</option>
           </select>
         </div>
 
@@ -80,6 +82,24 @@ export function WebSearchSection({ appSettings, patchSettings, inputClass }: Set
               <p className="text-[11px] text-emerald-400/90 mt-1.5">Stored securely. Clear the field and save to remove it.</p>
             )}
             <p className="text-[11px] text-text-3/60 mt-2">Get your API key from <a href="https://brave.com/search/api/" target="_blank" rel="noopener noreferrer" className="text-accent-bright hover:underline">brave.com/search/api</a></p>
+          </div>
+        )}
+
+        {provider === 'exa' && (
+          <div>
+            <label className="block font-display text-[11px] font-600 text-text-3 uppercase tracking-[0.08em] mb-2">Exa API Key</label>
+            <input
+              type="password"
+              value={appSettings.exaApiKey || ''}
+              onChange={(e) => patchSettings({ exaApiKey: e.target.value || null })}
+              placeholder={hasExaKey ? 'Stored securely. Enter a new key to replace it.' : 'exa-...'}
+              className={inputClass}
+              style={{ fontFamily: 'inherit' }}
+            />
+            {hasExaKey && (
+              <p className="text-[11px] text-emerald-400/90 mt-1.5">Stored securely. Clear the field and save to remove it.</p>
+            )}
+            <p className="text-[11px] text-text-3/60 mt-2">Get your API key from <a href="https://exa.ai" target="_blank" rel="noopener noreferrer" className="text-accent-bright hover:underline">exa.ai</a>. You can also set the <code className="text-[11px] font-mono text-text-2">EXA_API_KEY</code> environment variable.</p>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

- Adds **Exa** as a new web search provider option in the search provider dropdown (Settings > Web Search)
- Implements `ExaProvider` class using the Exa REST API with AI-powered neural search and content retrieval (highlights, text, summary)
- Supports API key configuration via the settings UI (stored securely), the `EXA_API_KEY` environment variable, or the secret store
- Includes `x-exa-integration: swarmclaw` tracking header on all API requests
- Graceful content fallback: prefers summary, falls back to highlights, then raw text for snippet generation

## Usage

1. Go to **Settings > Web Search**
2. Select **Exa** from the provider dropdown
3. Enter your Exa API key (get one at [exa.ai](https://exa.ai))

Alternatively, set the `EXA_API_KEY` environment variable.

```typescript
// The provider is resolved automatically from settings:
const provider = await getSearchProvider({ webSearchProvider: 'exa', exaApiKey: 'your-key' })
const results = await provider.search('latest AI research', 5)
// => [{ title: '...', url: '...', snippet: '...' }, ...]
```

## Files changed

- `src/lib/server/session-tools/search-providers.ts` -- new `ExaProvider` class + `ExaSearchResult` interface + `buildExaSnippet` helper + factory case
- `src/lib/server/session-tools/search-providers.test.ts` -- 8 new unit tests (response parsing, fallback logic, header verification, key resolution, error handling)
- `src/types/app-settings.ts` -- added `'exa'` to `webSearchProvider` union + `exaApiKey` / `exaApiKeyConfigured` fields
- `src/views/settings/section-web-search.tsx` -- Exa option in dropdown + API key input section
- `src/app/api/settings/route.ts` -- added `exaApiKey` to `SECRET_SETTING_KEYS` for secure storage

## Test plan

- [x] All 8 new unit tests pass (`npx tsx --test src/lib/server/session-tools/search-providers.test.ts`)
- [x] Existing web-inputs tests still pass (no regressions)
- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] Manual: select Exa provider in Settings, enter API key, verify search results appear
- [ ] Manual: verify EXA_API_KEY env var works when no key is set in settings
- [ ] Manual: verify error message when no API key is configured