### PR TITLE
fix: clear null depError on task create/update in task-sheet

### DIFF
--- a/src/components/tasks/task-sheet.tsx
+++ b/src/components/tasks/task-sheet.tsx
@@ -186,6 +186,7 @@ export function TaskSheet() {
 
   const onClose = () => {
     formInitRef.current = null
+    setDepError(null)
     setOpen(false)
     setEditingId(null)
   }
@@ -215,14 +216,16 @@ export function TaskSheet() {
     try {
       if (editing) {
         const res = await updateTaskMutation.mutateAsync({ id: editing.id, patch: payload })
-        if (res && typeof res === 'object' && 'error' in res) {
-          setDepError(String((res as unknown as Record<string, unknown>).error))
+        const errMsg = res && typeof res === 'object' ? (res as unknown as Record<string, unknown>).error : undefined
+        if (typeof errMsg === 'string' && errMsg.trim()) {
+          setDepError(errMsg)
           return
         }
       } else {
         const res = await createTaskMutation.mutateAsync(payload)
-        if (res && typeof res === 'object' && 'error' in res) {
-          setDepError(String((res as unknown as Record<string, unknown>).error))
+        const errMsg = res && typeof res === 'object' ? (res as unknown as Record<string, unknown>).error : undefined
+        if (typeof errMsg === 'string' && errMsg.trim()) {
+          setDepError(errMsg)
           return
         }
       }


### PR DESCRIPTION
## Problem

`BoardTask.error` is typed as `string | null`. When a task was successfully created or updated, the API returned the task object with `error: null`. The old guard (`'error' in res`) evaluated to `true` even for `null` values, causing `String(null)` → `"null"` to be rendered as a red error message below the **Blocked By** field.

## Fixes

- Replace `'error' in res` check with `typeof errMsg === 'string' && errMsg.trim()` so only a non-empty string triggers the error UI (both create and update paths)
- Clear `depError` in `onClose()` so stale error state cannot leak into a freshly-opened dialog

## Affected file

`src/components/tasks/task-sheet.tsx`