### PR TITLE
fix: model switcher shows and saves session model correctly

### DIFF
--- a/src/app/api/chats/[id]/execution-log/route.ts
+++ b/src/app/api/chats/[id]/execution-log/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server'
+import { notFound } from '@/lib/server/collection-helpers'
+import { getSession } from '@/lib/server/sessions/session-repository'
+import { queryLogs } from '@/lib/server/execution-log'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const session = getSession(id)
+  if (!session) return notFound()
+
+  const { searchParams } = new URL(req.url)
+  const limit = Math.min(200, Math.max(1, Number(searchParams.get('limit')) || 100))
+  const since = searchParams.get('since') ? Number(searchParams.get('since')) : undefined
+  const category = searchParams.get('category') as Parameters<typeof queryLogs>[0]['category'] | undefined
+
+  const entries = queryLogs({ sessionId: id, limit, since, category })
+  return NextResponse.json(entries)
+}

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -607,6 +607,7 @@ const COMMAND_GROUPS = [
         defaultBody: { action: 'status' },
       }),
       cmd('checkpoints', 'GET', '/chats/:id/checkpoints', 'List checkpoint history for a chat'),
+      cmd('execution-log', 'GET', '/chats/:id/execution-log', 'Get execution log entries for a chat'),
       cmd('migrate-messages', 'POST', '/chats/migrate-messages', 'Migrate messages from session blobs to relational table'),
     ],
   },

--- a/src/components/agents/inspector-panel.tsx
+++ b/src/components/agents/inspector-panel.tsx
@@ -73,22 +73,24 @@ function ModelSwitcherInline({ session, agent }: { session: Session; agent: Agen
   const refreshSession = useAppStore((s) => s.refreshSession)
   const streaming = useChatStore((s) => s.streaming)
   const [expanded, setExpanded] = useState(false)
-  const [selectedProvider, setSelectedProvider] = useState(agent.provider)
+  const [selectedProvider, setSelectedProvider] = useState(session.provider || agent.provider)
   const [saving, setSaving] = useState(false)
 
   useEffect(() => {
     void loadProviders()
     void loadProviderConfigs()
   }, [loadProviderConfigs, loadProviders])
-  useEffect(() => { setSelectedProvider(agent.provider) }, [agent.provider])
+  // Sync selectedProvider when the session's provider changes (e.g. after a successful save)
+  useEffect(() => { setSelectedProvider(session.provider || agent.provider) }, [session.provider, agent.provider])
 
   const agentSelectableProviders = useMemo(
     () => buildAgentSelectableProviders(providers, providerConfigs),
     [providerConfigs, providers],
   )
   const currentProviderInfo = agentSelectableProviders.find((p) => p.id === selectedProvider)
-  const activeAgentProvider = agentSelectableProviders.find((p) => p.id === agent.provider)
-  const providerLabel = PROVIDER_LABELS[agent.provider] || activeAgentProvider?.name || agent.provider.replace(/-/g, ' ')
+  const activeSessionProvider = agentSelectableProviders.find((p) => p.id === (session.provider || agent.provider))
+  const effectiveProvider = session.provider || agent.provider
+  const providerLabel = PROVIDER_LABELS[effectiveProvider] || activeSessionProvider?.name || effectiveProvider.replace(/-/g, ' ')
 
   const handleModelChange = async (model: string) => {
     if (saving) return
@@ -117,7 +119,7 @@ function ModelSwitcherInline({ session, agent }: { session: Session; agent: Agen
           {providerLabel}
         </span>
         <span className="inline-flex max-w-[180px] items-center rounded-[8px] border border-white/[0.06] bg-white/[0.03] px-2 py-1 text-[10px] font-mono text-text-3/70 truncate group-hover:border-white/[0.1] group-hover:text-text-2 transition-colors">
-          {agent.model || 'Default model'}
+          {session.model || agent.model || 'Default model'}
         </span>
         <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" className="text-text-3/30 group-hover:text-text-3/60 transition-colors ml-auto shrink-0">
           <polyline points="6 9 12 15 18 9" />
@@ -157,7 +159,7 @@ function ModelSwitcherInline({ session, agent }: { session: Session; agent: Agen
       {currentProviderInfo && (
         <ModelCombobox
           providerId={currentProviderInfo.id}
-          value={agent.model || currentProviderInfo.models[0] || ''}
+          value={session.model || agent.model || currentProviderInfo.models[0] || ''}
           onChange={(m) => void handleModelChange(m)}
           models={currentProviderInfo.models}
           defaultModels={currentProviderInfo.defaultModels}

--- a/src/components/chat/session-debug-panel.tsx
+++ b/src/components/chat/session-debug-panel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import type { Message } from '@/types'
 import { IconButton } from '@/components/shared/icon-button'
 import { CheckpointTimeline } from './checkpoint-timeline'
@@ -19,7 +19,20 @@ interface DebugEvent {
   type: EventType
   label: string
   detail: string
+  extraDetail?: Record<string, unknown> | null
   time: number
+  source: 'message' | 'execlog'
+}
+
+interface ExecLogEntry {
+  id: string
+  sessionId: string
+  runId: string | null
+  agentId: string | null
+  category: string
+  summary: string
+  detail: Record<string, unknown> | null
+  ts: number
 }
 
 function classifyMessage(msg: Message): DebugEvent {
@@ -27,30 +40,66 @@ function classifyMessage(msg: Message): DebugEvent {
 
   if (msg.role === 'user') {
     if (text.startsWith('[System]')) {
-      return { type: 'system', label: 'System', detail: text.replace('[System] ', ''), time: msg.time }
+      return { type: 'system', label: 'System', detail: text.replace('[System] ', ''), time: msg.time, source: 'message' }
     }
     if (text.startsWith('[Agent ')) {
       const match = text.match(/\[Agent (.+?) result\]/)
-      return { type: 'agent_result', label: `Agent: ${match?.[1] || 'Unknown'}`, detail: text.replace(/\[Agent .+? result\]:?\n?/, ''), time: msg.time }
+      return { type: 'agent_result', label: `Agent: ${match?.[1] || 'Unknown'}`, detail: text.replace(/\[Agent .+? result\]:?\n?/, ''), time: msg.time, source: 'message' }
     }
     if (text.startsWith('[Memory search')) {
-      return { type: 'system', label: 'Memory Search', detail: text.replace('[Memory search results]:\n', ''), time: msg.time }
+      return { type: 'system', label: 'Memory Search', detail: text.replace('[Memory search results]:\n', ''), time: msg.time, source: 'message' }
     }
-    return { type: 'user', label: 'User', detail: text, time: msg.time }
+    return { type: 'user', label: 'User', detail: text, time: msg.time, source: 'message' }
   }
 
   // assistant
   if (text.startsWith('[Delegating to ')) {
     const match = text.match(/\[Delegating to (.+?)\]/)
-    return { type: 'delegation', label: `Delegate: ${match?.[1] || 'Unknown'}`, detail: text.replace(/\[Delegating to .+?\]:?\s?/, ''), time: msg.time }
+    return { type: 'delegation', label: `Delegate: ${match?.[1] || 'Unknown'}`, detail: text.replace(/\[Delegating to .+?\]:?\s?/, ''), time: msg.time, source: 'message' }
   }
   if (text.startsWith('[Error]')) {
-    return { type: 'error', label: 'Error', detail: text.replace('[Error] ', ''), time: msg.time }
+    return { type: 'error', label: 'Error', detail: text.replace('[Error] ', ''), time: msg.time, source: 'message' }
   }
   if (text.startsWith('Starting task:')) {
-    return { type: 'system', label: 'Task Start', detail: text, time: msg.time }
+    return { type: 'system', label: 'Task Start', detail: text, time: msg.time, source: 'message' }
   }
-  return { type: 'assistant', label: 'Assistant', detail: text, time: msg.time }
+  return { type: 'assistant', label: 'Assistant', detail: text, time: msg.time, source: 'message' }
+}
+
+function classifyExecLogEntry(entry: ExecLogEntry): DebugEvent {
+  const catMap: Record<string, EventType> = {
+    error: 'error',
+    tool_call: 'tool_call',
+    tool_result: 'tool_call',
+    decision: 'system',
+    trigger: 'system',
+    loop_detection: 'system',
+    delegation_start: 'delegation',
+    delegation_complete: 'agent_result',
+    delegation_fail: 'error',
+  }
+  const type: EventType = catMap[entry.category] ?? 'system'
+  const labelMap: Record<string, string> = {
+    error: 'Error',
+    tool_call: 'Tool Call',
+    tool_result: 'Tool Result',
+    decision: 'Decision',
+    trigger: 'Trigger',
+    loop_detection: 'Loop Detect',
+    delegation_start: 'Delegation',
+    delegation_complete: 'Delegation Result',
+    delegation_fail: 'Delegation Error',
+    heartbeat_failure: 'Heartbeat Fail',
+  }
+  const label = labelMap[entry.category] ?? entry.category.replace(/_/g, ' ')
+  return {
+    type,
+    label,
+    detail: entry.summary,
+    extraDetail: entry.detail,
+    time: entry.ts,
+    source: 'execlog',
+  }
 }
 
 const TYPE_COLORS: Record<EventType, string> = {
@@ -67,14 +116,66 @@ function fmtTime(ts: number) {
   return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
 }
 
+function ExtraDetail({ data }: { data: Record<string, unknown> }) {
+  const entries = Object.entries(data).filter(([, v]) => v !== null && v !== undefined)
+  if (entries.length === 0) return null
+  return (
+    <div className="mt-2 rounded-[8px] bg-black/30 border border-white/[0.06] p-3 text-[11px] font-mono space-y-1">
+      {entries.map(([k, v]) => (
+        <div key={k} className="flex gap-2 flex-wrap">
+          <span className="text-text-3/70 shrink-0">{k}:</span>
+          <span className="text-text-2 break-all">
+            {Array.isArray(v)
+              ? v.map(String).join(', ') || '(empty)'
+              : typeof v === 'object'
+                ? JSON.stringify(v)
+                : String(v)}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
 export function SessionDebugPanel({ messages, open, onClose }: Props) {
   const [tab, setTab] = useState<'log' | 'checkpoints'>('log')
   const [filter, setFilter] = useState<EventType | 'all'>('all')
   const [expandedIdx, setExpandedIdx] = useState<number | null>(null)
-  
+  const [execLogs, setExecLogs] = useState<ExecLogEntry[]>([])
+  const [loadingExec, setLoadingExec] = useState(false)
+
   const currentSessionId = useAppStore(selectActiveSessionId)
 
-  const events = messages.map(classifyMessage)
+  const fetchExecLogs = useCallback(async (sessionId: string) => {
+    setLoadingExec(true)
+    try {
+      const res = await fetch(`/api/chats/${sessionId}/execution-log?limit=200`)
+      if (res.ok) {
+        const data = await res.json() as ExecLogEntry[]
+        setExecLogs(Array.isArray(data) ? data : [])
+      }
+    } catch {
+      // non-critical
+    } finally {
+      setLoadingExec(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (open && currentSessionId) {
+      void fetchExecLogs(currentSessionId)
+    } else if (!open) {
+      setExecLogs([])
+      setExpandedIdx(null)
+    }
+  }, [open, currentSessionId, fetchExecLogs])
+
+  const msgEvents = messages.map(classifyMessage)
+  const execEvents = execLogs.map(classifyExecLogEntry)
+
+  // Merge and sort by time
+  const allEvents = [...msgEvents, ...execEvents].sort((a, b) => a.time - b.time)
+  const events = allEvents
   const filtered = filter === 'all' ? events : events.filter((e) => e.type === filter)
 
   if (!open) return null
@@ -85,6 +186,7 @@ export function SessionDebugPanel({ messages, open, onClose }: Props) {
     { id: 'agent_result', label: 'Results' },
     { id: 'error', label: 'Errors' },
     { id: 'system', label: 'System' },
+    { id: 'tool_call', label: 'Tools' },
   ]
 
   return (
@@ -97,20 +199,20 @@ export function SessionDebugPanel({ messages, open, onClose }: Props) {
           <path d="M6 20v-4" />
         </svg>
         <span className="font-display text-[16px] font-600 tracking-[-0.02em] flex-1">Session X-Ray</span>
-        
+
         <div className="flex bg-white/[0.04] p-0.5 rounded-[8px] mr-2">
-           <button 
-             onClick={() => setTab('log')}
-             className={`px-3 py-1 rounded-[6px] text-[11px] font-600 transition-all ${tab === 'log' ? 'bg-white/[0.08] text-text shadow-sm' : 'text-text-3 hover:text-text-2'}`}
-           >
-             Event Log
-           </button>
-           <button 
-             onClick={() => setTab('checkpoints')}
-             className={`px-3 py-1 rounded-[6px] text-[11px] font-600 transition-all ${tab === 'checkpoints' ? 'bg-accent-soft text-accent-bright' : 'text-text-3 hover:text-text-2'}`}
-           >
-             Checkpoints
-           </button>
+          <button
+            onClick={() => setTab('log')}
+            className={`px-3 py-1 rounded-[6px] text-[11px] font-600 transition-all ${tab === 'log' ? 'bg-white/[0.08] text-text shadow-sm' : 'text-text-3 hover:text-text-2'}`}
+          >
+            Event Log
+          </button>
+          <button
+            onClick={() => setTab('checkpoints')}
+            className={`px-3 py-1 rounded-[6px] text-[11px] font-600 transition-all ${tab === 'checkpoints' ? 'bg-accent-soft text-accent-bright' : 'text-text-3 hover:text-text-2'}`}
+          >
+            Checkpoints
+          </button>
         </div>
 
         <IconButton onClick={onClose} aria-label="Close debug panel">
@@ -138,6 +240,16 @@ export function SessionDebugPanel({ messages, open, onClose }: Props) {
                 {f.label}
               </button>
             ))}
+            {currentSessionId && (
+              <button
+                onClick={() => void fetchExecLogs(currentSessionId)}
+                disabled={loadingExec}
+                className="ml-auto px-3 py-1.5 rounded-[8px] text-[11px] font-600 cursor-pointer transition-all border bg-surface border-white/[0.06] text-text-3 hover:text-text-2 disabled:opacity-40 whitespace-nowrap"
+                style={{ fontFamily: 'inherit' }}
+              >
+                {loadingExec ? 'Refreshing…' : '↺ Refresh'}
+              </button>
+            )}
           </div>
 
           {/* Event timeline */}
@@ -162,26 +274,39 @@ export function SessionDebugPanel({ messages, open, onClose }: Props) {
                     />
 
                     {/* Content */}
-                    <div className="flex items-center gap-2 mb-0.5">
+                    <div className="flex items-center gap-2 mb-0.5 flex-wrap">
                       <span className="text-[11px] font-700 uppercase tracking-wider" style={{ color }}>
                         {event.label}
                       </span>
                       <span className="text-[10px] text-text-3/70 font-mono">{fmtTime(event.time)}</span>
+                      {event.source === 'execlog' && (
+                        <span className="text-[9px] text-text-3/40 font-mono uppercase tracking-wider">exec</span>
+                      )}
                     </div>
 
                     <p className={`text-[12px] text-text-3 leading-[1.5] ${expanded ? 'whitespace-pre-wrap' : 'line-clamp-2'}`}>
                       {event.detail}
                     </p>
 
+                    {expanded && event.extraDetail && (
+                      <ExtraDetail data={event.extraDetail} />
+                    )}
+
                     {!expanded && event.detail.length > 150 && (
                       <span className="text-[11px] text-accent-bright/60 mt-1 inline-block">click to expand</span>
+                    )}
+                    {!expanded && event.extraDetail && Object.keys(event.extraDetail).length > 0 && (
+                      <span className="text-[11px] text-accent-bright/60 mt-1 inline-block ml-2">+ details</span>
                     )}
                   </button>
                 )
               })}
 
-              {filtered.length === 0 && (
+              {filtered.length === 0 && !loadingExec && (
                 <p className="text-center text-[13px] text-text-3 py-12">No events matching filter</p>
+              )}
+              {filtered.length === 0 && loadingExec && (
+                <p className="text-center text-[13px] text-text-3 py-12">Loading…</p>
               )}
             </div>
           </div>
@@ -198,17 +323,19 @@ export function SessionDebugPanel({ messages, open, onClose }: Props) {
                 </span>
               )
             })}
+            <span className="ml-auto text-[10px] text-text-3/40 font-mono">{execLogs.length} exec log entries</span>
           </div>
         </>
       ) : (
         <div className="flex-1 overflow-y-auto">
-           {currentSessionId ? (
-             <CheckpointTimeline sessionId={currentSessionId} />
-           ) : (
-             <div className="p-12 text-center text-text-3">No active chat</div>
-           )}
+          {currentSessionId ? (
+            <CheckpointTimeline sessionId={currentSessionId} />
+          ) : (
+            <div className="p-12 text-center text-text-3">No active chat</div>
+          )}
         </div>
       )}
     </div>
   )
 }
+

--- a/src/components/tasks/task-sheet.tsx
+++ b/src/components/tasks/task-sheet.tsx
@@ -186,6 +186,7 @@ export function TaskSheet() {
 
   const onClose = () => {
     formInitRef.current = null
+    setDepError(null)
     setOpen(false)
     setEditingId(null)
   }
@@ -215,14 +216,16 @@ export function TaskSheet() {
     try {
       if (editing) {
         const res = await updateTaskMutation.mutateAsync({ id: editing.id, patch: payload })
-        if (res && typeof res === 'object' && 'error' in res) {
-          setDepError(String((res as unknown as Record<string, unknown>).error))
+        const errMsg = res && typeof res === 'object' ? (res as unknown as Record<string, unknown>).error : undefined
+        if (typeof errMsg === 'string' && errMsg.trim()) {
+          setDepError(errMsg)
           return
         }
       } else {
         const res = await createTaskMutation.mutateAsync(payload)
-        if (res && typeof res === 'object' && 'error' in res) {
-          setDepError(String((res as unknown as Record<string, unknown>).error))
+        const errMsg = res && typeof res === 'object' ? (res as unknown as Record<string, unknown>).error : undefined
+        if (typeof errMsg === 'string' && errMsg.trim()) {
+          setDepError(errMsg)
           return
         }
       }

--- a/src/lib/server/chat-execution/chat-turn-finalization.ts
+++ b/src/lib/server/chat-execution/chat-turn-finalization.ts
@@ -33,6 +33,7 @@ import {
 import { estimateCost } from '@/lib/server/cost'
 import { refreshSessionIdentityState } from '@/lib/server/identity-continuity'
 import { log } from '@/lib/server/logger'
+import { logExecution } from '@/lib/server/execution-log'
 import { syncSessionArchiveMemory } from '@/lib/server/memory/session-archive-memory'
 import { runCapabilityHook, transformCapabilityText } from '@/lib/server/native-capabilities'
 import { isHeartbeatSource } from '@/lib/server/runtime/heartbeat-source'
@@ -287,6 +288,22 @@ export async function finalizeChatTurn(params: {
         inferredError: terminalError,
       })
     }
+    logExecution(sessionId, 'error', terminalError, {
+      runId,
+      agentId: sessionForRun.agentId || null,
+      detail: {
+        provider: providerType,
+        model: sessionForRun.model,
+        streamErrors: streamErrors.length > 0 ? streamErrors : undefined,
+        source,
+        durationMs,
+        inputTokens: directUsage.received ? directUsage.inputTokens : null,
+        outputTokens: directUsage.received ? directUsage.outputTokens : null,
+        tokenUsageReceived: directUsage.received,
+        hadResponse: !!(fullResponse || '').trim(),
+        toolEventCount: toolEvents.length,
+      },
+    })
     errorMessage = terminalError
   }
 


### PR DESCRIPTION
## Problem

The **Switch Model** panel in the agent inspector was using `agent.provider` / `agent.model` as source of truth instead of `session.provider` / `session.model`. This meant:

- `selectedProvider` always reset to the agent default after saving (not the newly-switched provider)
- The collapsed pill showed `agent.model` so the UI never reflected a successful switch
- The combobox `value` was seeded from `agent.model`, so reopening the switcher lost the change

## Fix

Use `session.provider` / `session.model` as source of truth throughout `ModelSwitcherInline`, falling back to `agent.provider` / `agent.model` when unset.

- `selectedProvider` initialised from `session.provider`
- `useEffect` syncs to `session.provider` changes (not just `agent.provider`)
- Collapsed provider label derived from `session.provider`
- Collapsed model pill shows `session.model`
- Combobox `value` uses `session.model`