### PR TITLE
Fix chatroom CLI runtime and allow full member selection

### DIFF
--- a/src/app/api/chatrooms/[id]/chat/route.test.ts
+++ b/src/app/api/chatrooms/[id]/chat/route.test.ts
@@ -297,3 +297,114 @@ test('chatroom route forwards tool activity and records one reply per participat
   assert.deepEqual(output.assistantCounts, { alpha: 1, beta: 1 })
   assert.deepEqual([...new Set(output.agentOrder)].sort(), ['alpha', 'beta'])
 })
+
+test('chatroom route uses direct provider runtime for CLI providers', () => {
+  const output = runWithTempDataDir<{
+    errors: string[]
+    streamedText: string
+    assistantTexts: string[]
+  }>(`
+    const storageMod = await import('./src/lib/server/storage')
+    const providersMod = await import('@/lib/providers')
+    const routeMod = await import('./src/app/api/chatrooms/[id]/chat/route')
+    const streamMod = await import('@/lib/server/chat-execution/stream-agent-chat')
+    const storage = storageMod.default || storageMod
+    const providers = providersMod.default || providersMod
+    const route = routeMod.default || routeMod
+    const stream = streamMod.default || streamMod
+
+    const originalHandler = providers.PROVIDERS['codex-cli'].handler
+
+    const now = Date.now()
+    storage.saveAgents({
+      alpha: {
+        id: 'alpha',
+        name: 'Alpha',
+        provider: 'codex-cli',
+        model: 'gpt-5.3-codex',
+        extensions: [],
+        createdAt: now,
+        updatedAt: now,
+      },
+    })
+    storage.saveChatrooms({
+      room_1: {
+        id: 'room_1',
+        name: 'CLI Room',
+        agentIds: ['alpha'],
+        messages: [],
+        createdAt: now,
+        updatedAt: now,
+        chatMode: 'sequential',
+        autoAddress: true,
+      },
+    })
+
+    async function readSse(response) {
+      const reader = response.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+      const events = []
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buffer += decoder.decode(value, { stream: true })
+        let idx = buffer.indexOf('\\n\\n')
+        while (idx !== -1) {
+          const chunk = buffer.slice(0, idx)
+          buffer = buffer.slice(idx + 2)
+          const line = chunk
+            .split('\\n')
+            .map((entry) => entry.trim())
+            .find((entry) => entry.startsWith('data: '))
+          if (line) {
+            events.push(JSON.parse(line.slice(6)))
+          }
+          idx = buffer.indexOf('\\n\\n')
+        }
+      }
+      return events
+    }
+
+    stream.setStreamAgentChatForTest(async () => {
+      throw new Error('streamAgentChat should not be called for codex-cli chatroom turns')
+    })
+    providers.PROVIDERS['codex-cli'].handler = {
+      streamChat: async (opts) => {
+        const reply = 'Codex CLI answered from direct provider runtime.'
+        opts.write('data: ' + JSON.stringify({ t: 'd', text: reply }) + '\\n')
+        return reply
+      },
+    }
+
+    try {
+      const response = await route.POST(
+        new Request('http://local/api/chatrooms/room_1/chat', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ senderId: 'user', text: 'Say hello to the room.' }),
+        }),
+        { params: Promise.resolve({ id: 'room_1' }) },
+      )
+
+      const events = await readSse(response)
+      const chatroom = storage.loadChatrooms().room_1
+      const assistantTexts = chatroom.messages
+        .filter((entry) => entry.role === 'assistant')
+        .map((entry) => entry.text)
+
+      console.log(JSON.stringify({
+        errors: events.filter((entry) => entry.t === 'err').map((entry) => entry.text),
+        streamedText: events.filter((entry) => entry.t === 'd').map((entry) => entry.text).join(''),
+        assistantTexts,
+      }))
+    } finally {
+      providers.PROVIDERS['codex-cli'].handler = originalHandler
+      stream.setStreamAgentChatForTest(null)
+    }
+  `, { prefix: 'swarmclaw-chatroom-route-cli-provider-' })
+
+  assert.equal(output.errors.some((text) => /streamAgentChat should not be called/i.test(text)), false)
+  assert.equal(output.streamedText.includes('Codex CLI answered from direct provider runtime.'), true)
+  assert.equal(output.assistantTexts.some((text) => text.includes('Codex CLI answered from direct provider runtime.')), true)
+})

--- a/src/app/api/chatrooms/[id]/chat/route.ts
+++ b/src/app/api/chatrooms/[id]/chat/route.ts
@@ -6,6 +6,7 @@ import { notFound } from '@/lib/server/collection-helpers'
 import { safeParseBody } from '@/lib/server/safe-parse-body'
 import { streamAgentChat } from '@/lib/server/chat-execution/stream-agent-chat'
 import { getProvider } from '@/lib/providers'
+import { NON_LANGGRAPH_PROVIDER_IDS } from '@/lib/provider-sets'
 import {
   resolveApiKey,
   parseMentions,
@@ -231,37 +232,55 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
 
             let fullText = ''
             let agentError = ''
-            const result = await streamAgentChat({
-              session: syntheticSession,
-              message: messageForAgent,
-              imagePath,
-              attachedFiles,
-              apiKey,
-              systemPrompt: fullSystemPrompt,
-              write: (raw: string) => {
-                const lines = raw.split('\n').filter(Boolean)
-                for (const line of lines) {
-                  if (!line.startsWith('data: ')) continue
-                  try {
-                    const parsed = JSON.parse(line.slice(6).trim())
-                    if (parsed.t === 'd' && parsed.text) {
-                      fullText += parsed.text
-                      writeEvent({ t: 'd', text: parsed.text, agentId: agent.id, agentName: agent.name })
-                    } else if (parsed.t === 'tool_call' || parsed.t === 'tool_result') {
-                      writeEvent({ ...parsed, agentId: agent.id, agentName: agent.name })
-                    } else if (parsed.t === 'err' && parsed.text) {
-                      agentError = parsed.text
-                      writeEvent({ t: 'err', text: parsed.text, agentId: agent.id, agentName: agent.name })
-                    }
-                  } catch {
-                    // skip malformed lines
+            const forwardProviderEvents = (raw: string) => {
+              const lines = raw.split('\n').filter(Boolean)
+              for (const line of lines) {
+                if (!line.startsWith('data: ')) continue
+                try {
+                  const parsed = JSON.parse(line.slice(6).trim())
+                  if (parsed.t === 'd' && parsed.text) {
+                    fullText += parsed.text
+                    writeEvent({ t: 'd', text: parsed.text, agentId: agent.id, agentName: agent.name })
+                  } else if (parsed.t === 'tool_call' || parsed.t === 'tool_result') {
+                    writeEvent({ ...parsed, agentId: agent.id, agentName: agent.name })
+                  } else if (parsed.t === 'err' && parsed.text) {
+                    agentError = parsed.text
+                    writeEvent({ t: 'err', text: parsed.text, agentId: agent.id, agentName: agent.name })
                   }
+                } catch {
+                  // skip malformed lines
                 }
-              },
-              history,
-            })
+              }
+            }
 
-            const rawResponseText = result.finalResponse || result.fullText || fullText
+            let rawResponseText = ''
+            if (NON_LANGGRAPH_PROVIDER_IDS.has(syntheticSession.provider)) {
+              const provider = getProvider(syntheticSession.provider)
+              if (!provider) throw new Error(`Unknown provider: ${syntheticSession.provider}`)
+              rawResponseText = await provider.handler.streamChat({
+                session: syntheticSession,
+                message: messageForAgent,
+                imagePath,
+                apiKey,
+                systemPrompt: fullSystemPrompt,
+                write: forwardProviderEvents,
+                active: new Map<string, unknown>(),
+                loadHistory: () => history,
+              })
+              if (!rawResponseText) rawResponseText = fullText
+            } else {
+              const result = await streamAgentChat({
+                session: syntheticSession,
+                message: messageForAgent,
+                imagePath,
+                attachedFiles,
+                apiKey,
+                systemPrompt: fullSystemPrompt,
+                write: forwardProviderEvents,
+                history,
+              })
+              rawResponseText = result.finalResponse || result.fullText || fullText
+            }
             const responseText = stripAgentReactionTokens(stripHiddenControlTokens(rawResponseText))
 
             // Don't persist empty or error-only messages — they pollute chat history

--- a/src/app/api/chatrooms/[id]/members/route.ts
+++ b/src/app/api/chatrooms/[id]/members/route.ts
@@ -4,7 +4,6 @@ import { notify } from '@/lib/server/ws-hub'
 import { notFound } from '@/lib/server/collection-helpers'
 import { safeParseBody } from '@/lib/server/safe-parse-body'
 import { genId } from '@/lib/id'
-import { isWorkerOnlyAgent, buildWorkerOnlyAgentMessage } from '@/lib/server/agents/agent-availability'
 
 export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
@@ -18,13 +17,6 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
   if (!agentId) return NextResponse.json({ error: 'agentId is required' }, { status: 400 })
 
   const agents = loadAgents()
-  if (isWorkerOnlyAgent(agents[agentId])) {
-    return NextResponse.json(
-      { error: buildWorkerOnlyAgentMessage(agents[agentId], 'join chatrooms') },
-      { status: 400 },
-    )
-  }
-
   if (!chatroom.agentIds.includes(agentId)) {
     chatroom.agentIds.push(agentId)
 

--- a/src/app/api/chatrooms/[id]/route.ts
+++ b/src/app/api/chatrooms/[id]/route.ts
@@ -4,7 +4,6 @@ import { notify } from '@/lib/server/ws-hub'
 import { notFound } from '@/lib/server/collection-helpers'
 import { safeParseBody } from '@/lib/server/safe-parse-body'
 import { genId } from '@/lib/id'
-import { isWorkerOnlyAgent } from '@/lib/server/agents/agent-availability'
 import {
   ensureChatroomRoutingGuidance,
   synthesizeRoutingGuidanceFromRules,
@@ -78,16 +77,6 @@ export async function PUT(req: Request, { params }: { params: Promise<{ id: stri
         { status: 400 },
       )
     }
-    const cliAgentNames = agentIds
-      .filter((agentId) => isWorkerOnlyAgent(agents[agentId]))
-      .map((agentId) => agents[agentId]?.name || agentId)
-    if (cliAgentNames.length > 0) {
-      return NextResponse.json(
-        { error: `CLI-based agents cannot join chatrooms: ${cliAgentNames.join(', ')}. They can only be used for direct chats and delegation.` },
-        { status: 400 },
-      )
-    }
-
     const oldIds = new Set(chatroom.agentIds)
     const newIds = new Set(agentIds)
     const added = agentIds.filter((aid: string) => !oldIds.has(aid))

--- a/src/app/api/chatrooms/route.ts
+++ b/src/app/api/chatrooms/route.ts
@@ -6,7 +6,6 @@ import { ChatroomCreateSchema, formatZodError } from '@/lib/validation/schemas'
 import { safeParseBody } from '@/lib/server/safe-parse-body'
 import { z } from 'zod'
 import type { Chatroom, ChatroomMessage } from '@/types'
-import { isWorkerOnlyAgent } from '@/lib/server/agents/agent-availability'
 import {
   ensureChatroomRoutingGuidance,
   synthesizeRoutingGuidanceFromRules,
@@ -58,15 +57,6 @@ export async function POST(req: Request) {
   if (invalidAgentIds.length > 0) {
     return NextResponse.json(
       { error: `Unknown chatroom member(s): ${invalidAgentIds.join(', ')}` },
-      { status: 400 },
-    )
-  }
-  const cliAgentNames = requestedAgentIds
-    .filter((agentId) => isWorkerOnlyAgent(knownAgents[agentId]))
-    .map((agentId) => knownAgents[agentId]?.name || agentId)
-  if (cliAgentNames.length > 0) {
-    return NextResponse.json(
-      { error: `CLI-based agents cannot join chatrooms: ${cliAgentNames.join(', ')}. They can only be used for direct chats and delegation.` },
       { status: 400 },
     )
   }

--- a/src/components/chatrooms/chatroom-sheet.tsx
+++ b/src/components/chatrooms/chatroom-sheet.tsx
@@ -9,7 +9,6 @@ import { toast } from 'sonner'
 import { AgentAvatar } from '@/components/agents/agent-avatar'
 import type { Agent } from '@/types'
 import { CheckIcon } from '@/components/shared/check-icon'
-import { WORKER_ONLY_PROVIDER_IDS } from '@/lib/provider-sets'
 
 export function ChatroomSheet() {
   const open = useChatroomStore((s) => s.chatroomSheetOpen)
@@ -105,9 +104,7 @@ export function ChatroomSheet() {
     )
   }
 
-  const agentList = Object.values(agents).filter(
-    (a: Agent) => !a.trashedAt && !WORKER_ONLY_PROVIDER_IDS.has(a.provider)
-  ) as Agent[]
+  const agentList = Object.values(agents).filter((a: Agent) => !a.trashedAt) as Agent[]
 
   return (
     <BottomSheet open={open} onClose={() => setChatroomSheetOpen(false)}>

--- a/src/lib/server/session-tools/chatroom.ts
+++ b/src/lib/server/session-tools/chatroom.ts
@@ -12,7 +12,6 @@ import { log } from '../logger'
 import { debug } from '../debug'
 import { logExecution } from '../execution-log'
 import { logActivity } from '../storage'
-import { WORKER_ONLY_PROVIDER_IDS } from '@/lib/provider-sets'
 
 /**
  * Core Chatroom Execution Logic
@@ -78,12 +77,6 @@ async function executeChatroomAction(args: Record<string, unknown>, context: { a
       const agents = loadAgents()
       const requestedAgentIds = agentIds || []
       const validAgentIds = requestedAgentIds.filter((aid: string) => !!agents[aid])
-      const cliAgentNames = validAgentIds
-        .filter((aid: string) => WORKER_ONLY_PROVIDER_IDS.has(agents[aid]?.provider))
-        .map((aid: string) => agents[aid]?.name || aid)
-      if (cliAgentNames.length > 0) {
-        return `Error: CLI-based agents cannot join chatrooms: ${cliAgentNames.join(', ')}. They can only be used for direct chats and delegation.`
-      }
 
       const chatroom: Chatroom = {
         id,
@@ -208,10 +201,6 @@ async function executeChatroomAction(args: Record<string, unknown>, context: { a
 
     if (action === 'add_agent') {
       if (!agentId) return 'Error: agentId required.'
-      const agents = loadAgents()
-      if (WORKER_ONLY_PROVIDER_IDS.has(agents[agentId]?.provider)) {
-        return `Error: ${agents[agentId]?.name || agentId} is a CLI-based agent and cannot join chatrooms. CLI agents can only be used for direct chats and delegation.`
-      }
       if (!chatroom.agentIds.includes(agentId)) {
         chatroom.agentIds.push(agentId)
         chatroom.updatedAt = Date.now()


### PR DESCRIPTION
## Summary
- fix chatroom execution for CLI-backed providers (codex-cli/copilot-cli and other non-LangGraph providers) by routing room turns through provider direct runtime instead of `streamAgentChat`
- keep normal LangGraph path for providers that support agentic runtime
- restore full chatroom member selection by allowing non-trashed agents in UI and removing worker-only chatroom membership blocks in create/update/members APIs and session chatroom tools
- add regression test proving CLI providers in chatrooms bypass `streamAgentChat` and stream/persist correctly

## Notes
- this PR includes the member-allowance changes that conflicted in #52
- intended to replace/supersede #52