### PR TITLE
Fix structured runs and agent session UX

### DIFF
--- a/src/app/api/runs/[id]/events/route.ts
+++ b/src/app/api/runs/[id]/events/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server'
 import { getRunById, listRunEvents } from '@/lib/server/runtime/session-run-manager'
+import { listProtocolRunEventsForRun, loadProtocolRunById } from '@/lib/server/protocols/protocol-queries'
+import { protocolEventToRunEventRecord } from '@/lib/server/runs/unified-run-records'
 
 export const dynamic = 'force-dynamic'
 
@@ -12,11 +14,15 @@ function parseLimit(value: string | null): number | undefined {
 export async function GET(req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
   const run = getRunById(id)
-  if (!run) {
-    return NextResponse.json({ error: 'Run not found' }, { status: 404 })
+  if (run) {
+    const url = new URL(req.url)
+    const limit = parseLimit(url.searchParams.get('limit'))
+    return NextResponse.json(listRunEvents(id, limit))
   }
-
+  const protocolRun = loadProtocolRunById(id)
+  if (!protocolRun) return NextResponse.json({ error: 'Run not found' }, { status: 404 })
   const url = new URL(req.url)
   const limit = parseLimit(url.searchParams.get('limit'))
-  return NextResponse.json(listRunEvents(id, limit))
+  const events = listProtocolRunEventsForRun(id, limit || 200).map((event) => protocolEventToRunEventRecord(protocolRun, event))
+  return NextResponse.json(events)
 }

--- a/src/app/api/runs/[id]/route.ts
+++ b/src/app/api/runs/[id]/route.ts
@@ -1,9 +1,13 @@
 import { NextResponse } from 'next/server'
 import { getRunById } from '@/lib/server/runtime/session-run-manager'
+import { loadProtocolRunById } from '@/lib/server/protocols/protocol-queries'
+import { protocolRunToSessionRunRecord } from '@/lib/server/runs/unified-run-records'
 
 export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
   const run = getRunById(id)
-  if (!run) return NextResponse.json({ error: 'Run not found' }, { status: 404 })
-  return NextResponse.json(run)
+  if (run) return NextResponse.json(run)
+  const protocolRun = loadProtocolRunById(id)
+  if (protocolRun) return NextResponse.json(protocolRunToSessionRunRecord(protocolRun))
+  return NextResponse.json({ error: 'Run not found' }, { status: 404 })
 }

--- a/src/app/api/runs/route.test.ts
+++ b/src/app/api/runs/route.test.ts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { runWithTempDataDir } from '@/lib/server/test-utils/run-with-temp-data-dir'
+
+test('runs routes include structured schedule protocol runs', () => {
+  const output = runWithTempDataDir<{
+    listCount: number
+    firstRunId: string | null
+    firstRunSource: string | null
+    firstRunStatus: string | null
+    detailId: string | null
+    detailSource: string | null
+    eventsCount: number
+    eventSummary: string | null
+  }>(`
+    const storageMod = await import('./src/lib/server/storage')
+    const protocolsMod = await import('./src/lib/server/protocols/protocol-service')
+    const listRouteMod = await import('./src/app/api/runs/route')
+    const detailRouteMod = await import('./src/app/api/runs/[id]/route')
+    const eventsRouteMod = await import('./src/app/api/runs/[id]/events/route')
+    const storage = storageMod.default || storageMod
+    const protocols = protocolsMod.default || protocolsMod
+    const listRoute = listRouteMod.default || listRouteMod
+    const detailRoute = detailRouteMod.default || detailRouteMod
+    const eventsRoute = eventsRouteMod.default || eventsRouteMod
+
+    storage.upsertStoredItem('agents', 'agentA', {
+      id: 'agentA',
+      name: 'Agent A',
+      provider: 'ollama',
+      model: 'test-model',
+      systemPrompt: 'test',
+      createdAt: 1,
+      updatedAt: 1,
+    })
+
+    const run = protocols.createProtocolRun({
+      title: 'Scheduled structured run',
+      participantAgentIds: ['agentA'],
+      facilitatorAgentId: 'agentA',
+      autoStart: false,
+      scheduleId: 'sched-1',
+      sourceRef: { kind: 'schedule', id: 'sched-1', label: 'Morning schedule' },
+      config: {
+        goal: 'Summarize the morning inbox.',
+      },
+    })
+
+    const listResponse = await listRoute.GET(new Request('http://local/api/runs?limit=10'))
+    const listPayload = await listResponse.json()
+
+    const detailResponse = await detailRoute.GET(
+      new Request('http://local/api/runs/' + run.id),
+      { params: Promise.resolve({ id: run.id }) },
+    )
+    const detailPayload = await detailResponse.json()
+
+    const eventsResponse = await eventsRoute.GET(
+      new Request('http://local/api/runs/' + run.id + '/events?limit=10'),
+      { params: Promise.resolve({ id: run.id }) },
+    )
+    const eventsPayload = await eventsResponse.json()
+
+    console.log(JSON.stringify({
+      listCount: Array.isArray(listPayload) ? listPayload.length : -1,
+      firstRunId: Array.isArray(listPayload) && listPayload[0] ? listPayload[0].id : null,
+      firstRunSource: Array.isArray(listPayload) && listPayload[0] ? listPayload[0].source : null,
+      firstRunStatus: Array.isArray(listPayload) && listPayload[0] ? listPayload[0].status : null,
+      detailId: detailPayload?.id || null,
+      detailSource: detailPayload?.source || null,
+      eventsCount: Array.isArray(eventsPayload) ? eventsPayload.length : -1,
+      eventSummary: Array.isArray(eventsPayload) && eventsPayload[0] ? eventsPayload[0].summary || null : null,
+    }))
+  `, { prefix: 'swarmclaw-runs-route-' })
+
+  assert.equal(output.listCount, 1)
+  assert.equal(output.firstRunId, output.detailId)
+  assert.equal(output.firstRunSource, 'structured schedule')
+  assert.equal(output.firstRunStatus, 'queued')
+  assert.equal(output.detailSource, 'structured schedule')
+  assert.equal(output.eventsCount >= 1, true)
+  assert.equal(typeof output.eventSummary, 'string')
+})

--- a/src/app/api/runs/route.ts
+++ b/src/app/api/runs/route.ts
@@ -2,9 +2,26 @@ import { NextResponse } from 'next/server'
 import { listRuns } from '@/lib/server/runtime/session-run-manager'
 import { listProtocolRuns } from '@/lib/server/protocols/protocol-queries'
 import { protocolRunToSessionRunRecord } from '@/lib/server/runs/unified-run-records'
-import type { SessionRunStatus } from '@/types'
+import type { ProtocolRunStatus, SessionRunStatus } from '@/types'
 
 export const dynamic = 'force-dynamic'
+
+function protocolStatusesForRunStatus(status?: SessionRunStatus): ProtocolRunStatus[] {
+  switch (status) {
+    case 'queued':
+      return ['draft']
+    case 'running':
+      return ['running', 'waiting', 'paused']
+    case 'completed':
+      return ['completed']
+    case 'failed':
+      return ['failed']
+    case 'cancelled':
+      return ['cancelled', 'archived']
+    default:
+      return []
+  }
+}
 
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url)
@@ -14,13 +31,25 @@ export async function GET(req: Request) {
   const limit = limitRaw ? Number.parseInt(limitRaw, 10) : undefined
 
   const sessionRuns = listRuns({ sessionId, status, limit })
-  const protocolRuns = listProtocolRuns({ includeSystemOwned: true, limit: limit || 200 })
+  const fetchLimit = limit || 200
+  const scopedProtocolRuns = status
+    ? protocolStatusesForRunStatus(status).flatMap((protocolStatus) => listProtocolRuns({
+      includeSystemOwned: true,
+      sessionId,
+      status: protocolStatus,
+      limit: fetchLimit,
+    }))
+    : listProtocolRuns({
+      includeSystemOwned: true,
+      sessionId,
+      limit: fetchLimit,
+    })
+  const protocolRuns = Array.from(new Map(scopedProtocolRuns.map((run) => [run.id, run])).values())
     .filter((run) => run.status !== 'archived')
     .map(protocolRunToSessionRunRecord)
-    .filter((run) => !sessionId || run.sessionId === sessionId)
     .filter((run) => !status || run.status === status)
   const runs = [...sessionRuns, ...protocolRuns]
     .sort((left, right) => (right.queuedAt || 0) - (left.queuedAt || 0))
-    .slice(0, limit || 200)
+    .slice(0, fetchLimit)
   return NextResponse.json(runs)
 }

--- a/src/app/api/runs/route.ts
+++ b/src/app/api/runs/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server'
 import { listRuns } from '@/lib/server/runtime/session-run-manager'
+import { listProtocolRuns } from '@/lib/server/protocols/protocol-queries'
+import { protocolRunToSessionRunRecord } from '@/lib/server/runs/unified-run-records'
 import type { SessionRunStatus } from '@/types'
 
 export const dynamic = 'force-dynamic'
@@ -11,6 +13,14 @@ export async function GET(req: Request) {
   const limitRaw = searchParams.get('limit')
   const limit = limitRaw ? Number.parseInt(limitRaw, 10) : undefined
 
-  const runs = listRuns({ sessionId, status, limit })
+  const sessionRuns = listRuns({ sessionId, status, limit })
+  const protocolRuns = listProtocolRuns({ includeSystemOwned: true, limit: limit || 200 })
+    .filter((run) => run.status !== 'archived')
+    .map(protocolRunToSessionRunRecord)
+    .filter((run) => !sessionId || run.sessionId === sessionId)
+    .filter((run) => !status || run.status === status)
+  const runs = [...sessionRuns, ...protocolRuns]
+    .sort((left, right) => (right.queuedAt || 0) - (left.queuedAt || 0))
+    .slice(0, limit || 200)
   return NextResponse.json(runs)
 }

--- a/src/components/agents/inspector-panel.tsx
+++ b/src/components/agents/inspector-panel.tsx
@@ -6,6 +6,7 @@ import type { Agent, MemoryEntry, Session } from '@/types'
 import { useAppStore } from '@/stores/use-app-store'
 import { useChatStore } from '@/stores/use-chat-store'
 import { api } from '@/lib/app/api-client'
+import { sortSessionsNewestFirst } from '@/lib/chat/new-session'
 import { AgentAvatar } from './agent-avatar'
 import { AgentFilesEditor } from './agent-files-editor'
 import { OpenClawSkillsPanel } from './openclaw-skills-panel'
@@ -907,7 +908,7 @@ function SessionsSection({ agent }: { agent: Agent }) {
   const setInspectorOpen = useAppStore((s) => s.setInspectorOpen)
 
   const agentSessions = useMemo(() => {
-    return Object.values(sessions).filter((s) => s.agentId === agent.id)
+    return sortSessionsNewestFirst(Object.values(sessions).filter((s) => s.agentId === agent.id))
   }, [sessions, agent.id])
 
   if (agentSessions.length === 0) return null

--- a/src/components/chat/chat-area.tsx
+++ b/src/components/chat/chat-area.tsx
@@ -31,6 +31,7 @@ import { api } from '@/lib/app/api-client'
 import { messagesDiffer } from '@/lib/chat/chat-streaming-state'
 import { createAssistantRenderId } from '@/lib/chat/assistant-render-id'
 import { getSessionLastMessage } from '@/lib/chat/session-summary'
+import { buildNewAgentSessionPayload, summarizeFirstMessageAsTitle } from '@/lib/chat/new-session'
 import { getEnabledCapabilityIds, getEnabledToolIds } from '@/lib/capability-selection'
 
 const DIRECT_PROMPT_SUGGESTIONS = [
@@ -57,6 +58,8 @@ export function ChatArea() {
   const setCurrentAgent = useAppStore((s) => s.setCurrentAgent)
   const removeSessionFromStore = useAppStore((s) => s.removeSession)
   const refreshSession = useAppStore((s) => s.refreshSession)
+  const updateSessionInStore = useAppStore((s) => s.updateSessionInStore)
+  const setActiveSessionIdOverride = useAppStore((s) => s.setActiveSessionIdOverride)
   const appSettings = useAppStore((s) => s.appSettings)
   const messages = useChatStore((s) => s.messages)
   const messageStartIndex = useChatStore((s) => s.messageStartIndex)
@@ -172,6 +175,7 @@ export function ChatArea() {
   const hasMultipleSources = connectorSources.size > 1 || (connectorSources.size > 0 && hasDirectMessages)
   const [isDragging, setIsDragging] = useState(false)
   const dragCounter = useRef(0)
+  const freshSessionIdRef = useRef<string | null>(null)
   const setPendingImage = useChatStore((s) => s.setPendingImage)
 
   useEffect(() => {
@@ -180,6 +184,13 @@ export function ChatArea() {
     const requestedSessionId = sessionId
     const chatState = useChatStore.getState()
     const preserveLocalStream = chatState.streaming && chatState.streamingSessionId === requestedSessionId
+    if (freshSessionIdRef.current === requestedSessionId) {
+      freshSessionIdRef.current = null
+      setMessages([], { startIndex: 0, totalMessages: 0 })
+      useChatStore.setState({ hasMoreMessages: false })
+      setMessagesLoading(false)
+      return () => { cancelled = true }
+    }
     // Clear stale messages immediately so the skeleton loader shows instead of
     // the previous chat's messages flashing briefly during the fetch.
     if (!preserveLocalStream) setMessages([], { startIndex: 0, totalMessages: 0 })
@@ -431,7 +442,7 @@ export function ChatArea() {
     setDevServer(null)
   }, [sessionId, setDevServer])
 
-  const handleClear = useCallback(async () => {
+  const handleClear = useCallback(async (mode: 'clear' | 'new-session' = 'clear') => {
     setConfirmClear(false)
     if (!sessionId) return
     const targetSessionId = sessionId
@@ -448,7 +459,11 @@ export function ChatArea() {
     await refreshSession(targetSessionId)
     const { undoToken, cleared } = result
     if (!undoToken) return
-    const clearedLabel = cleared === 1 ? '1 message cleared' : `${cleared.toLocaleString()} messages cleared`
+    const clearedLabel = mode === 'new-session'
+      ? 'Started a fresh chat session.'
+      : cleared === 1
+        ? '1 message cleared'
+        : `${cleared.toLocaleString()} messages cleared`
     toast(clearedLabel, {
       duration: 10_000,
       action: {
@@ -486,6 +501,34 @@ export function ChatArea() {
   const handleClearRequest = useCallback(() => {
     setConfirmClear(true)
   }, [])
+
+  const handleStartNewSession = useCallback(async () => {
+    if (!session) return
+    try {
+      const nextSession = await api<typeof session>('POST', '/chats', {
+        ...buildNewAgentSessionPayload(session),
+        name: currentAgent?.name || session.name,
+      })
+      freshSessionIdRef.current = nextSession.id
+      updateSessionInStore(nextSession)
+      setActiveSessionIdOverride(nextSession.id)
+      toast.success('Started a new chat session.')
+    } catch (err) {
+      toast.error(`Could not start a new chat session: ${errorMessage(err)}`)
+    }
+  }, [currentAgent?.name, session, setActiveSessionIdOverride, updateSessionInStore])
+
+  const handleSend = useCallback(async (text: string) => {
+    if (!sessionId) return
+    if (session && messages.length === 0) {
+      const nextTitle = summarizeFirstMessageAsTitle(text, currentAgent?.name || session.name)
+      if (nextTitle && nextTitle !== session.name) {
+        updateSessionInStore({ ...session, name: nextTitle })
+        void api('PUT', `/chats/${sessionId}`, { name: nextTitle }).catch(() => {})
+      }
+    }
+    await sendMessage(text, { sessionId })
+  }, [currentAgent?.name, messages.length, sendMessage, session, sessionId, updateSessionInStore])
 
   const handleDelete = useCallback(async () => {
     setConfirmDelete(false)
@@ -568,6 +611,7 @@ export function ChatArea() {
           messageCount={messages.length}
           onCompactComplete={handleCompactComplete}
           onClearRequest={handleClearRequest}
+          onStartNewSession={handleStartNewSession}
         />
       )}
       {!isDesktop && (
@@ -589,6 +633,7 @@ export function ChatArea() {
           messageCount={messages.length}
           onCompactComplete={handleCompactComplete}
           onClearRequest={handleClearRequest}
+          onStartNewSession={handleStartNewSession}
         />
       )}
       <DevServerBar status={devServerStatus} onStop={handleStopDevServer} />
@@ -691,13 +736,13 @@ export function ChatArea() {
         onClose={() => setDebugOpen(false)}
       />
 
-      <ChatInput
-        streaming={streamingForThisSession}
-        busy={streamingForThisSession || session.active === true}
-        onSend={sendMessage}
-        onStop={stopStreaming}
-        extensionChatActions={extensionChatActions}
-      />
+        <ChatInput
+          streaming={streamingForThisSession}
+          busy={streamingForThisSession || session.active === true}
+          onSend={handleSend}
+          onStop={stopStreaming}
+          extensionChatActions={extensionChatActions}
+        />
 
       <Dropdown open={menuOpen} onClose={() => setMenuOpen(false)}>
         <DropdownItem onClick={() => {
@@ -720,7 +765,7 @@ export function ChatArea() {
         message="Clear every message in this chat. Long-term memory, skills, and facts are preserved. You'll have 10 seconds to undo."
         confirmLabel="Clear"
         danger
-        onConfirm={handleClear}
+        onConfirm={() => { void handleClear('clear') }}
         onCancel={() => setConfirmClear(false)}
       />
       <ConfirmDialog

--- a/src/components/chat/chat-header.tsx
+++ b/src/components/chat/chat-header.tsx
@@ -17,6 +17,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip
 import { copyTextToClipboard } from '@/lib/clipboard'
 import { useNavigate } from '@/lib/app/navigation'
 import { getEnabledToolIds } from '@/lib/capability-selection'
+import { getNewSessionButtonTitle, hasResettableSessionRuntime } from '@/lib/chat/new-session'
 import { ContextMeterBadge } from './context-meter-badge'
 
 function Tip({ label, children, side = 'bottom' }: { label: string; children: ReactNode; side?: 'top' | 'bottom' | 'left' | 'right' }) {
@@ -84,9 +85,10 @@ interface Props {
   messageCount?: number
   onCompactComplete?: () => void
   onClearRequest?: () => void
+  onStartNewSession?: () => void
 }
 
-export function ChatHeader({ session, streaming, onStop, onMenuToggle, onBack, mobile, browserActive, onStopBrowser, onVoiceToggle, voiceActive, voiceSupported, connectorSources, connectorFilter, onConnectorFilterChange, hasMultipleSources, messageCount = 0, onCompactComplete, onClearRequest }: Props) {
+export function ChatHeader({ session, streaming, onStop, onMenuToggle, onBack, mobile, browserActive, onStopBrowser, onVoiceToggle, voiceActive, voiceSupported, connectorSources, connectorFilter, onConnectorFilterChange, hasMultipleSources, messageCount = 0, onCompactComplete, onClearRequest, onStartNewSession }: Props) {
   const now = useNow()
   const agentStatus = useChatStore((s) => s.agentStatus)
   const agents = useAppStore((s) => s.agents)
@@ -114,6 +116,8 @@ export function ChatHeader({ session, streaming, onStop, onMenuToggle, onBack, m
   const renameInputRef = useRef<HTMLInputElement>(null)
   const renameContainerRef = useRef<HTMLSpanElement>(null)
   const liveStatus = agentStatus || null
+  const canStartNewSession = !streaming && !!onStartNewSession && (messageCount > 0 || hasResettableSessionRuntime(session))
+  const newSessionTitle = getNewSessionButtonTitle(session)
   const connectorPresenceMeta = useMemo(() => {
     if (!connector) return null
     const lastAt = connectorPresence?.lastMessageAt
@@ -430,6 +434,23 @@ export function ChatHeader({ session, streaming, onStop, onMenuToggle, onBack, m
                 onCompactComplete={onCompactComplete}
                 onClearRequest={onClearRequest}
               />
+            )}
+            {canStartNewSession && (
+              <Tip label={newSessionTitle}>
+                <button
+                  type="button"
+                  onClick={onStartNewSession}
+                  className="inline-flex items-center gap-1.5 rounded-[9px] border border-white/[0.06] bg-white/[0.03] px-2.5 py-1 text-[10px] font-600 text-text-3/70 transition-colors shrink-0 cursor-pointer hover:border-white/[0.15] hover:bg-white/[0.05] hover:text-text-2"
+                  aria-label="Start a new chat session"
+                  title={newSessionTitle}
+                >
+                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <path d="M12 5v14" />
+                    <path d="M5 12h14" />
+                  </svg>
+                  <span>New chat</span>
+                </button>
+              </Tip>
             )}
           </div>
           {liveStatus?.status && (

--- a/src/components/schedules/schedule-console.tsx
+++ b/src/components/schedules/schedule-console.tsx
@@ -119,6 +119,7 @@ function mapTaskStatus(status: BoardTask['status']): ScheduleConsoleRunRow['stat
     case 'queued':
       return status
     case 'archived':
+      return 'cancelled'
     default:
       return 'queued'
   }

--- a/src/components/schedules/schedule-console.tsx
+++ b/src/components/schedules/schedule-console.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useMemo, useState, type ButtonHTMLAttributes } from 'react'
+import { useRouter } from 'next/navigation'
 import { AgentAvatar } from '@/components/agents/agent-avatar'
 import { PageLoader } from '@/components/ui/page-loader'
 import { SearchInput } from '@/components/ui/search-input'
@@ -9,10 +10,11 @@ import { SectionHeader } from '@/components/ui/section-header'
 import { useNow } from '@/hooks/use-now'
 import { useWs } from '@/hooks/use-ws'
 import { useAppStore } from '@/stores/use-app-store'
+import { api } from '@/lib/app/api-client'
 import { archiveSchedule, purgeSchedule, restoreSchedule, runSchedule, updateSchedule } from '@/lib/schedules/schedules'
 import { cronToHuman } from '@/lib/schedules/cron-human'
 import { timeAgo, timeUntil } from '@/lib/time-format'
-import type { BoardTask, Schedule, ScheduleStatus } from '@/types'
+import type { BoardTask, ProtocolRun, Schedule, ScheduleStatus } from '@/types'
 import { toast } from 'sonner'
 
 type ScheduleScope = 'live' | 'archived' | 'runs'
@@ -21,6 +23,18 @@ type ScheduleRunStatusFilter = 'all' | Extract<BoardTask['status'], 'queued' | '
 type ScheduleCadenceFilter = 'all' | Schedule['scheduleType']
 type ScheduleDeliveryFilter = 'all' | 'ok' | 'error' | 'unknown'
 type ScheduleSortBy = 'nextRunAt' | 'lastRunAt' | 'updatedAt' | 'name'
+type ScheduleConsoleRunRow = {
+  id: string
+  kind: 'task' | 'protocol'
+  status: Extract<BoardTask['status'], 'queued' | 'running' | 'completed' | 'failed' | 'cancelled'>
+  title: string
+  preview: string
+  updatedAt: number
+  createdAt: number
+  agentId: string
+  scheduleId: string | null
+  scheduleName: string
+}
 
 const STATUS_STYLES: Record<string, string> = {
   active: 'bg-emerald-500/12 text-emerald-400 border-emerald-500/20',
@@ -76,6 +90,54 @@ function runPreview(task: BoardTask): string {
   return (result || error || task.description || '').slice(0, 180) || 'No run summary yet.'
 }
 
+function mapProtocolStatus(status: ProtocolRun['status']): ScheduleConsoleRunRow['status'] {
+  switch (status) {
+    case 'draft':
+      return 'queued'
+    case 'running':
+    case 'waiting':
+    case 'paused':
+      return 'running'
+    case 'completed':
+      return 'completed'
+    case 'failed':
+      return 'failed'
+    case 'cancelled':
+    case 'archived':
+      return 'cancelled'
+    default:
+      return 'queued'
+  }
+}
+
+function mapTaskStatus(status: BoardTask['status']): ScheduleConsoleRunRow['status'] {
+  switch (status) {
+    case 'running':
+    case 'completed':
+    case 'failed':
+    case 'cancelled':
+    case 'queued':
+      return status
+    case 'archived':
+    default:
+      return 'queued'
+  }
+}
+
+function protocolRunPreview(run: ProtocolRun): string {
+  const summary = typeof run.summary === 'string' ? run.summary.trim() : ''
+  if (summary) return summary.slice(0, 180)
+  const latestArtifact = Array.isArray(run.artifacts)
+    ? [...run.artifacts].sort((left, right) => (right.createdAt || 0) - (left.createdAt || 0))[0]
+    : null
+  const artifactContent = typeof latestArtifact?.content === 'string' ? latestArtifact.content.trim() : ''
+  if (artifactContent) return artifactContent.slice(0, 180)
+  const error = typeof run.lastError === 'string' ? run.lastError.trim() : ''
+  if (error) return error.slice(0, 180)
+  const goal = typeof run.config?.goal === 'string' ? run.config.goal.trim() : ''
+  return (goal || run.title || 'Structured session run').slice(0, 180)
+}
+
 function ActionButton(
   props: ButtonHTMLAttributes<HTMLButtonElement> & { tone?: 'default' | 'danger' },
 ) {
@@ -96,6 +158,7 @@ function ActionButton(
 }
 
 export function ScheduleConsole() {
+  const router = useRouter()
   const now = useNow()
   const schedules = useAppStore((s) => s.schedules)
   const tasks = useAppStore((s) => s.tasks)
@@ -119,12 +182,23 @@ export function ScheduleConsole() {
   const [sortBy, setSortBy] = useState<ScheduleSortBy>('nextRunAt')
   const [busyId, setBusyId] = useState('')
   const [loaded, setLoaded] = useState(false)
+  const [protocolRuns, setProtocolRuns] = useState<ProtocolRun[]>([])
+
+  const fetchProtocolRuns = async () => {
+    try {
+      const runs = await api<ProtocolRun[]>('GET', '/protocols/runs?includeSystemOwned=true&sourceKind=schedule&limit=200')
+      setProtocolRuns(Array.isArray(runs) ? runs : [])
+    } catch {
+      setProtocolRuns([])
+    }
+  }
 
   useEffect(() => {
-    void Promise.all([loadSchedules(), loadTasks(), loadAgents()]).then(() => setLoaded(true))
+    void Promise.all([loadSchedules(), loadTasks(), loadAgents(), fetchProtocolRuns()]).then(() => setLoaded(true))
   }, [loadAgents, loadSchedules, loadTasks])
   useWs('schedules', loadSchedules, 5_000)
   useWs('tasks', loadTasks, 5_000)
+  useWs('protocol_runs', fetchProtocolRuns, 5_000)
 
   useEffect(() => {
     if (scope === 'runs') {
@@ -142,6 +216,10 @@ export function ScheduleConsole() {
 
   const scheduleRows = useMemo(() => Object.values(schedules), [schedules])
   const runRows = useMemo(() => Object.values(tasks).filter((task) => task.sourceType === 'schedule'), [tasks])
+  const protocolRunRows = useMemo(
+    () => protocolRuns.filter((run) => run.sourceRef.kind === 'schedule' && run.status !== 'archived'),
+    [protocolRuns],
+  )
   const projectScopedSchedules = useMemo(
     () => scheduleRows.filter((schedule) => !activeProjectFilter || schedule.projectId === activeProjectFilter),
     [activeProjectFilter, scheduleRows],
@@ -149,6 +227,14 @@ export function ScheduleConsole() {
   const projectScopedRuns = useMemo(
     () => runRows.filter((task) => !activeProjectFilter || task.projectId === activeProjectFilter),
     [activeProjectFilter, runRows],
+  )
+  const projectScopedProtocolRuns = useMemo(
+    () => protocolRunRows.filter((run) => {
+      if (!activeProjectFilter) return true
+      const sourceSchedule = typeof run.scheduleId === 'string' ? schedules[run.scheduleId] : null
+      return !!sourceSchedule && sourceSchedule.projectId === activeProjectFilter
+    }),
+    [activeProjectFilter, protocolRunRows, schedules],
   )
 
   const summary = useMemo(() => {
@@ -200,31 +286,55 @@ export function ScheduleConsole() {
       })
   }, [agentFilter, agents, cadenceFilter, deliveryFilter, projectScopedSchedules, scope, search, sortBy, statusFilter])
 
-  const filteredRuns = useMemo(() => {
+  const filteredRuns = useMemo<ScheduleConsoleRunRow[]>(() => {
     const q = search.trim().toLowerCase()
-    return projectScopedRuns
-      .filter((task) => {
-        if (runStatusFilter !== 'all' && task.status !== runStatusFilter) return false
-        if (agentFilter !== 'all' && task.agentId !== agentFilter) return false
+    const normalizedTaskRuns: ScheduleConsoleRunRow[] = projectScopedRuns.map((task) => ({
+      id: task.id,
+      kind: 'task',
+      status: mapTaskStatus(task.status),
+      title: task.title,
+      preview: runPreview(task),
+      updatedAt: task.updatedAt || task.createdAt,
+      createdAt: task.createdAt,
+      agentId: task.agentId,
+      scheduleId: typeof task.sourceScheduleId === 'string' ? task.sourceScheduleId : null,
+      scheduleName: typeof task.sourceScheduleName === 'string' ? task.sourceScheduleName : 'Scheduled run',
+    }))
+    const normalizedProtocolRuns: ScheduleConsoleRunRow[] = projectScopedProtocolRuns.map((run) => {
+      const sourceSchedule = typeof run.scheduleId === 'string' ? schedules[run.scheduleId] : null
+      return {
+        id: run.id,
+        kind: 'protocol',
+        status: mapProtocolStatus(run.status),
+        title: run.title,
+        preview: protocolRunPreview(run),
+        updatedAt: run.updatedAt || run.createdAt,
+        createdAt: run.createdAt,
+        agentId: run.facilitatorAgentId || run.participantAgentIds[0] || '',
+        scheduleId: typeof run.scheduleId === 'string' ? run.scheduleId : null,
+        scheduleName: sourceSchedule?.name || run.title || 'Structured session',
+      }
+    })
+    return [...normalizedTaskRuns, ...normalizedProtocolRuns]
+      .filter((entry) => {
+        if (runStatusFilter !== 'all' && entry.status !== runStatusFilter) return false
+        if (agentFilter !== 'all' && entry.agentId !== agentFilter) return false
         if (cadenceFilter !== 'all') {
-          const sourceSchedule = typeof task.sourceScheduleId === 'string' ? schedules[task.sourceScheduleId] : null
+          const sourceSchedule = entry.scheduleId ? schedules[entry.scheduleId] : null
           if (!sourceSchedule || sourceSchedule.scheduleType !== cadenceFilter) return false
         }
         if (!q) return true
-        const agentName = agents[task.agentId]?.name || ''
-        const sourceSchedule = typeof task.sourceScheduleName === 'string' ? task.sourceScheduleName : ''
+        const agentName = agents[entry.agentId]?.name || ''
         const haystack = [
-          task.title,
-          task.description,
-          sourceSchedule,
-          task.result,
-          task.error,
+          entry.title,
+          entry.preview,
+          entry.scheduleName,
           agentName,
         ].filter(Boolean).join(' ').toLowerCase()
         return haystack.includes(q)
       })
-      .sort((a, b) => (b.updatedAt || b.createdAt) - (a.updatedAt || a.createdAt))
-  }, [agentFilter, agents, cadenceFilter, projectScopedRuns, runStatusFilter, schedules, search])
+      .sort((a, b) => b.updatedAt - a.updatedAt)
+  }, [agentFilter, agents, cadenceFilter, projectScopedProtocolRuns, projectScopedRuns, runStatusFilter, schedules, search])
 
   const handleArchive = async (scheduleId: string) => {
     setBusyId(scheduleId)
@@ -275,7 +385,7 @@ export function ScheduleConsole() {
       const result = await runSchedule(scheduleId)
       if ('queued' in result && result.queued === false) toast.message('Schedule already has an in-flight run')
       else toast.success('Schedule run queued')
-      await Promise.all([loadSchedules(), loadTasks()])
+      await Promise.all([loadSchedules(), loadTasks(), fetchProtocolRuns()])
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to run schedule')
     } finally {
@@ -305,6 +415,10 @@ export function ScheduleConsole() {
   const openTask = (taskId: string) => {
     setEditingTaskId(taskId)
     setTaskSheetOpen(true)
+  }
+
+  const openProtocolRun = (runId: string) => {
+    router.push(`/protocols?runId=${encodeURIComponent(runId)}`)
   }
 
   const resetFilters = () => {
@@ -469,21 +583,22 @@ export function ScheduleConsole() {
             <div className="divide-y divide-white/[0.05]">
               {filteredRuns.length === 0 ? (
                 <div className="px-5 py-10 text-center text-text-3/60">No schedule runs match the current filters.</div>
-              ) : filteredRuns.map((task) => {
-                const agent = agents[task.agentId]
-                const sourceSchedule = typeof task.sourceScheduleId === 'string' ? schedules[task.sourceScheduleId] : null
+              ) : filteredRuns.map((run) => {
+                const agent = run.agentId ? agents[run.agentId] : null
+                const sourceSchedule = run.scheduleId ? schedules[run.scheduleId] : null
                 return (
-                  <div key={task.id} className="px-5 py-4 hover:bg-white/[0.02] transition-colors">
+                  <div key={`${run.kind}:${run.id}`} className="px-5 py-4 hover:bg-white/[0.02] transition-colors">
                     <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
                       <div className="min-w-0">
                         <div className="flex flex-wrap items-center gap-2 mb-1.5">
-                          <span className={`px-2 py-0.5 rounded-[8px] border text-[10px] font-700 uppercase tracking-[0.08em] ${badgeClass(task.status)}`}>{task.status}</span>
-                          {sourceSchedule && (
-                            <span className="text-[11px] text-text-3/60 uppercase tracking-[0.08em]">{sourceSchedule.name}</span>
-                          )}
+                          <span className={`px-2 py-0.5 rounded-[8px] border text-[10px] font-700 uppercase tracking-[0.08em] ${badgeClass(run.status)}`}>{run.status}</span>
+                          <span className="text-[11px] text-text-3/60 uppercase tracking-[0.08em]">{run.scheduleName}</span>
+                          <span className="text-[11px] text-text-3/40 uppercase tracking-[0.08em]">
+                            {run.kind === 'protocol' ? 'Structured session' : 'Legacy task'}
+                          </span>
                         </div>
-                        <div className="text-[15px] font-600 text-text-2">{task.title}</div>
-                        <div className="text-[13px] text-text-3 mt-1 line-clamp-2">{runPreview(task)}</div>
+                        <div className="text-[15px] font-600 text-text-2">{run.title}</div>
+                        <div className="text-[13px] text-text-3 mt-1 line-clamp-2">{run.preview}</div>
                         <div className="flex flex-wrap items-center gap-2 mt-3">
                           {agent && (
                             <div className="inline-flex items-center gap-2 rounded-[10px] bg-white/[0.03] px-2.5 py-1.5 text-[12px] text-text-2">
@@ -496,11 +611,13 @@ export function ScheduleConsole() {
                               <span>{agent.name}</span>
                             </div>
                           )}
-                          <span className="text-[12px] text-text-3/60">Updated {timeAgo(task.updatedAt, now)}</span>
+                          <span className="text-[12px] text-text-3/60">Updated {timeAgo(run.updatedAt, now)}</span>
                         </div>
                       </div>
                       <div className="flex flex-wrap items-center gap-2 shrink-0">
-                        <ActionButton onClick={() => openTask(task.id)}>Open Task</ActionButton>
+                        <ActionButton onClick={() => run.kind === 'protocol' ? openProtocolRun(run.id) : openTask(run.id)}>
+                          {run.kind === 'protocol' ? 'Open Run' : 'Open Task'}
+                        </ActionButton>
                         {sourceSchedule && sourceSchedule.status !== 'archived' && (
                           <ActionButton onClick={() => openSchedule(sourceSchedule.id)}>Open Schedule</ActionButton>
                         )}

--- a/src/lib/chat/new-session.test.ts
+++ b/src/lib/chat/new-session.test.ts
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  buildNewAgentSessionPayload,
+  getNewSessionButtonTitle,
+  hasResettableSessionRuntime,
+  sortSessionsNewestFirst,
+  summarizeFirstMessageAsTitle,
+} from './new-session'
+
+test('getNewSessionButtonTitle includes the Copilot CLI native reset hint', () => {
+  const title = getNewSessionButtonTitle({
+    provider: 'copilot-cli',
+    claudeSessionId: null,
+    codexThreadId: null,
+    opencodeSessionId: null,
+    opencodeWebSessionId: null,
+    geminiSessionId: null,
+    copilotSessionId: 'copilot-session-1',
+    droidSessionId: null,
+    cursorSessionId: null,
+    qwenSessionId: null,
+    acpSessionId: null,
+    delegateResumeIds: undefined,
+  })
+
+  assert.match(title, /Copilot CLI/)
+  assert.match(title, /\/new/)
+})
+
+test('hasResettableSessionRuntime detects saved provider or delegate resume ids', () => {
+  assert.equal(hasResettableSessionRuntime({
+    provider: 'openai',
+    claudeSessionId: null,
+    codexThreadId: null,
+    opencodeSessionId: null,
+    opencodeWebSessionId: null,
+    geminiSessionId: null,
+    copilotSessionId: null,
+    droidSessionId: null,
+    cursorSessionId: null,
+    qwenSessionId: null,
+    acpSessionId: null,
+    delegateResumeIds: { codex: 'resume-1' },
+  }), true)
+
+  assert.equal(hasResettableSessionRuntime({
+    provider: 'openai',
+    claudeSessionId: null,
+    codexThreadId: null,
+    opencodeSessionId: null,
+    opencodeWebSessionId: null,
+    geminiSessionId: null,
+    copilotSessionId: null,
+    droidSessionId: null,
+    cursorSessionId: null,
+    qwenSessionId: null,
+    acpSessionId: null,
+    delegateResumeIds: undefined,
+  }), false)
+})
+
+test('buildNewAgentSessionPayload clones the current agent chat settings for a fresh session', () => {
+  const payload = buildNewAgentSessionPayload({
+    id: 'sess-current',
+    name: 'Slackado',
+    cwd: '/workspace',
+    user: 'bnikolov',
+    provider: 'copilot-cli',
+    model: 'gpt-5.4-mini',
+    ollamaMode: null,
+    credentialId: null,
+    fallbackCredentialIds: ['cred-a'],
+    apiEndpoint: null,
+    routePreferredGatewayTags: ['primary'],
+    routePreferredGatewayUseCase: 'chat',
+    sessionType: 'human',
+    agentId: 'agent-1',
+    tools: ['shell'],
+    extensions: ['ext-a'],
+    heartbeatEnabled: null,
+    heartbeatIntervalSec: null,
+    sessionResetMode: 'idle',
+    sessionIdleTimeoutSec: 900,
+    sessionMaxAgeSec: null,
+    sessionDailyResetAt: null,
+    sessionResetTimezone: null,
+    thinkingLevel: 'medium',
+  })
+
+  assert.equal(payload.parentSessionId, 'sess-current')
+  assert.equal(payload.agentId, 'agent-1')
+  assert.equal(payload.provider, 'copilot-cli')
+  assert.deepEqual(payload.tools, ['shell'])
+})
+
+test('sortSessionsNewestFirst puts the latest active session first', () => {
+  const ordered = sortSessionsNewestFirst([
+    { id: 'older', createdAt: 100, lastActiveAt: 150 },
+    { id: 'newest', createdAt: 200, lastActiveAt: 500 },
+    { id: 'middle', createdAt: 300, lastActiveAt: 320 },
+  ])
+
+  assert.deepEqual(ordered.map((session) => session.id), ['newest', 'middle', 'older'])
+})
+
+test('summarizeFirstMessageAsTitle turns the opening prompt into a compact session title', () => {
+  assert.equal(
+    summarizeFirstMessageAsTitle('Review the latest CI failures for the dashboard and tell me what broke first.'),
+    'Review the latest CI failures for the dashboard',
+  )
+  assert.equal(summarizeFirstMessageAsTitle('   '), 'New Chat')
+})

--- a/src/lib/chat/new-session.ts
+++ b/src/lib/chat/new-session.ts
@@ -1,0 +1,146 @@
+import type { ProviderId, Session } from '@/types'
+
+type SessionResetSnapshot = Pick<
+  Session,
+  | 'provider'
+  | 'claudeSessionId'
+  | 'codexThreadId'
+  | 'opencodeSessionId'
+  | 'opencodeWebSessionId'
+  | 'geminiSessionId'
+  | 'copilotSessionId'
+  | 'droidSessionId'
+  | 'cursorSessionId'
+  | 'qwenSessionId'
+  | 'acpSessionId'
+  | 'delegateResumeIds'
+>
+
+type AgentSessionCloneSource = Pick<
+  Session,
+  | 'id'
+  | 'name'
+  | 'cwd'
+  | 'user'
+  | 'provider'
+  | 'model'
+  | 'ollamaMode'
+  | 'credentialId'
+  | 'fallbackCredentialIds'
+  | 'apiEndpoint'
+  | 'routePreferredGatewayTags'
+  | 'routePreferredGatewayUseCase'
+  | 'sessionType'
+  | 'agentId'
+  | 'tools'
+  | 'extensions'
+  | 'heartbeatEnabled'
+  | 'heartbeatIntervalSec'
+  | 'sessionResetMode'
+  | 'sessionIdleTimeoutSec'
+  | 'sessionMaxAgeSec'
+  | 'sessionDailyResetAt'
+  | 'sessionResetTimezone'
+  | 'thinkingLevel'
+>
+
+const PROVIDER_RESET_HINTS: Partial<Record<ProviderId, { label: string; equivalentCommand?: string }>> = {
+  'copilot-cli': { label: 'Copilot CLI', equivalentCommand: '/new' },
+}
+
+const CLI_PROVIDER_IDS = new Set<ProviderId>([
+  'claude-cli',
+  'codex-cli',
+  'opencode-cli',
+  'gemini-cli',
+  'copilot-cli',
+  'droid-cli',
+  'cursor-cli',
+  'qwen-code-cli',
+  'goose',
+])
+
+export function hasResettableSessionRuntime(session: SessionResetSnapshot): boolean {
+  return Boolean(
+    session.claudeSessionId
+      || session.codexThreadId
+      || session.opencodeSessionId
+      || session.opencodeWebSessionId
+      || session.geminiSessionId
+      || session.copilotSessionId
+      || session.droidSessionId
+      || session.cursorSessionId
+      || session.qwenSessionId
+      || session.acpSessionId
+      || session.delegateResumeIds?.claudeCode
+      || session.delegateResumeIds?.codex
+      || session.delegateResumeIds?.opencode
+      || session.delegateResumeIds?.gemini
+      || session.delegateResumeIds?.copilot
+      || session.delegateResumeIds?.droid
+      || session.delegateResumeIds?.cursor
+      || session.delegateResumeIds?.qwen
+  )
+}
+
+export function getNewSessionButtonTitle(session: SessionResetSnapshot): string {
+  const providerHint = PROVIDER_RESET_HINTS[session.provider]
+  if (providerHint?.equivalentCommand) {
+    return `Create a brand-new chat session. For ${providerHint.label}, this starts fresh instead of reusing the saved thread (equivalent to ${providerHint.equivalentCommand}).`
+  }
+  if (CLI_PROVIDER_IDS.has(session.provider)) {
+    return 'Create a brand-new chat session without reusing the saved CLI thread.'
+  }
+  return 'Create a brand-new chat session and keep the current conversation intact.'
+}
+
+export function buildNewAgentSessionPayload(session: AgentSessionCloneSource): Record<string, unknown> {
+  return {
+    name: session.name,
+    cwd: session.cwd,
+    user: session.user,
+    provider: session.provider,
+    model: session.model,
+    ollamaMode: session.ollamaMode ?? null,
+    credentialId: session.credentialId ?? null,
+    fallbackCredentialIds: session.fallbackCredentialIds ?? [],
+    apiEndpoint: session.apiEndpoint ?? null,
+    routePreferredGatewayTags: session.routePreferredGatewayTags ?? [],
+    routePreferredGatewayUseCase: session.routePreferredGatewayUseCase ?? null,
+    sessionType: session.sessionType ?? 'human',
+    agentId: session.agentId ?? null,
+    parentSessionId: session.id,
+    tools: session.tools ?? [],
+    extensions: session.extensions ?? [],
+    heartbeatEnabled: session.heartbeatEnabled ?? null,
+    heartbeatIntervalSec: session.heartbeatIntervalSec ?? null,
+    sessionResetMode: session.sessionResetMode ?? null,
+    sessionIdleTimeoutSec: session.sessionIdleTimeoutSec ?? null,
+    sessionMaxAgeSec: session.sessionMaxAgeSec ?? null,
+    sessionDailyResetAt: session.sessionDailyResetAt ?? null,
+    sessionResetTimezone: session.sessionResetTimezone ?? null,
+    thinkingLevel: session.thinkingLevel ?? null,
+  }
+}
+
+export function sortSessionsNewestFirst<T extends Pick<Session, 'createdAt' | 'lastActiveAt'>>(sessions: T[]): T[] {
+  return [...sessions].sort((left, right) => {
+    const leftTime = left.lastActiveAt || left.createdAt || 0
+    const rightTime = right.lastActiveAt || right.createdAt || 0
+    return rightTime - leftTime
+  })
+}
+
+export function summarizeFirstMessageAsTitle(text: string, fallback = 'New Chat'): string {
+  const cleaned = text
+    .replace(/\s+/g, ' ')
+    .replace(/[`*_#>\[\]]/g, '')
+    .trim()
+  if (!cleaned) return fallback
+  const sentenceMatch = cleaned.match(/^(.+?[.!?])(?:\s|$)/)
+  const sentence = (sentenceMatch?.[1] || cleaned).trim()
+  const words = sentence.split(' ').filter(Boolean).slice(0, 8)
+  const shortened = words.join(' ').trim()
+  if (!shortened) return fallback
+  return shortened.length > 60 ? `${shortened.slice(0, 57).trimEnd()}...` : shortened
+}

--- a/src/lib/server/daemon/controller.test.ts
+++ b/src/lib/server/daemon/controller.test.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { after, before, describe, it } from 'node:test'
+
+const originalEnv = {
+  DATA_DIR: process.env.DATA_DIR,
+  WORKSPACE_DIR: process.env.WORKSPACE_DIR,
+  SWARMCLAW_BUILD_MODE: process.env.SWARMCLAW_BUILD_MODE,
+  SWARMCLAW_DAEMON_AUTOSTART: process.env.SWARMCLAW_DAEMON_AUTOSTART,
+  SWARMCLAW_DAEMON_BACKGROUND_SERVICES: process.env.SWARMCLAW_DAEMON_BACKGROUND_SERVICES,
+}
+
+let tempDir = ''
+let daemonState: typeof import('@/lib/server/runtime/daemon-state')
+let controller: typeof import('@/lib/server/daemon/controller')
+let adminMetadata: typeof import('@/lib/server/daemon/admin-metadata')
+
+before(async () => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'swarmclaw-daemon-controller-'))
+  process.env.DATA_DIR = path.join(tempDir, 'data')
+  process.env.WORKSPACE_DIR = path.join(tempDir, 'workspace')
+  process.env.SWARMCLAW_BUILD_MODE = '1'
+  process.env.SWARMCLAW_DAEMON_AUTOSTART = '0'
+
+  daemonState = await import('@/lib/server/runtime/daemon-state')
+  controller = await import('@/lib/server/daemon/controller')
+  adminMetadata = await import('@/lib/server/daemon/admin-metadata')
+})
+
+after(async () => {
+  try { await daemonState.stopDaemon({ source: 'test-cleanup' }) } catch { /* ignore */ }
+  adminMetadata.clearDaemonAdminMetadata()
+  for (const [key, val] of Object.entries(originalEnv)) {
+    if (val === undefined) delete process.env[key]
+    else process.env[key] = val
+  }
+  fs.rmSync(tempDir, { recursive: true, force: true })
+})
+
+describe('daemon controller in-process mode', () => {
+  it('reports in-process daemon as running', async () => {
+    daemonState.startDaemon({ source: 'test', manualStart: true })
+    try {
+      const status = await controller.getDaemonStatusSnapshot()
+      const health = await controller.getDaemonHealthSummarySnapshot()
+      assert.equal(status.running, true)
+      assert.equal(status.schedulerActive, true)
+      assert.equal(health.components.daemon.status, 'healthy')
+    } finally {
+      await daemonState.stopDaemon({ source: 'test-cleanup' })
+    }
+  })
+
+  it('starts daemon in-process when manually requested', async () => {
+    await daemonState.stopDaemon({ source: 'test-prep' })
+    adminMetadata.clearDaemonAdminMetadata()
+
+    const started = await controller.ensureDaemonProcessRunning('test-start', { manualStart: true })
+    try {
+      assert.equal(started, true)
+      assert.equal(daemonState.getDaemonStatus().running, true)
+      assert.equal(adminMetadata.readDaemonAdminMetadata(), null)
+    } finally {
+      await daemonState.stopDaemon({ source: 'test-cleanup' })
+    }
+  })
+
+  it('stops in-process daemon via controller without subprocess metadata', async () => {
+    daemonState.startDaemon({ source: 'test-stop', manualStart: true })
+    adminMetadata.clearDaemonAdminMetadata()
+
+    const stopped = await controller.stopDaemonProcess({ source: 'test-stop', manualStop: true })
+    assert.equal(stopped, true)
+    assert.equal(daemonState.getDaemonStatus().running, false)
+  })
+})

--- a/src/lib/server/daemon/controller.ts
+++ b/src/lib/server/daemon/controller.ts
@@ -25,7 +25,12 @@ import type {
 } from '@/lib/server/daemon/types'
 import { DATA_DIR } from '@/lib/server/data-dir'
 import { loadEstopState } from '@/lib/server/runtime/estop'
-import { getDaemonStatus } from '@/lib/server/runtime/daemon-state/core'
+import {
+  getDaemonHealthSummary,
+  getDaemonStatus,
+  startDaemon,
+  stopDaemon,
+} from '@/lib/server/runtime/daemon-state/core'
 import { daemonAutostartEnvEnabled } from '@/lib/server/runtime/daemon-policy'
 import {
   releaseRuntimeLock,
@@ -164,6 +169,15 @@ async function readJsonResponse<T>(response: Response): Promise<T> {
 type DaemonSnapshotResponse = {
   status: DaemonStatusPayload
   healthSummary: DaemonHealthSummaryPayload
+}
+
+function getInProcessDaemonSnapshot(): DaemonSnapshotResponse | null {
+  const status = getDaemonStatus()
+  if (!status.running) return null
+  return {
+    status,
+    healthSummary: getDaemonHealthSummary() as DaemonHealthSummaryPayload,
+  }
 }
 
 async function requestDaemon<T>(
@@ -352,17 +366,18 @@ export async function ensureDaemonProcessRunning(
   source: string,
   opts?: { manualStart?: boolean },
 ): Promise<boolean> {
-  // In dev mode, the daemon may already be running in-process (same Next.js server)
-  // without a daemon-admin.json file. Check in-process state first to avoid spawning
-  // a subprocess that fails to acquire the already-held lease.
-  const inProcessStatus = getDaemonStatus()
-  if (inProcessStatus.running) return false
-
   const manualStart = opts?.manualStart === true
   const record = loadDaemonStatusRecord()
   if (loadEstopState().level !== 'none') return false
   if (!manualStart && !daemonAutostartEnvEnabled()) return false
   if (!manualStart && record.manualStopRequested) return false
+
+  const inProcessSnapshot = getInProcessDaemonSnapshot()
+  if (inProcessSnapshot) return false
+
+  const startedInProcess = startDaemon({ source, manualStart })
+  if (startedInProcess) return true
+  if (getInProcessDaemonSnapshot()) return false
 
   const live = await getLiveDaemonSnapshot()
   if (live?.status.running) return false
@@ -448,6 +463,28 @@ export async function stopDaemonProcess(opts?: {
   const source = opts?.source || 'unknown'
   const manualStop = opts?.manualStop === true
   const metadata = readDaemonAdminMetadata()
+  const inProcessSnapshot = getInProcessDaemonSnapshot()
+
+  if (inProcessSnapshot && (!metadata || metadata.pid === process.pid || !isProcessRunning(metadata.pid))) {
+    await stopDaemon({ source, manualStop })
+    clearDaemonAdminMetadata()
+    patchDaemonStatusRecord((current) => ({
+      ...current,
+      pid: null,
+      adminPort: null,
+      desiredState: 'stopped',
+      manualStopRequested: manualStop ? true : current.manualStopRequested,
+      stoppedAt: now(),
+      updatedAt: now(),
+      lastStopSource: source,
+      lastStatus: {
+        ...getDaemonStatus(),
+        manualStopRequested: manualStop ? true : current.manualStopRequested,
+      },
+      lastHealthSummary: getDaemonHealthSummary() as DaemonHealthSummaryPayload,
+    }))
+    return true
+  }
 
   if (!metadata || !isProcessRunning(metadata.pid)) {
     clearDaemonAdminMetadata()
@@ -510,12 +547,16 @@ export async function stopDaemonProcess(opts?: {
 }
 
 export async function getDaemonStatusSnapshot(): Promise<DaemonStatusPayload> {
+  const inProcessSnapshot = getInProcessDaemonSnapshot()
+  if (inProcessSnapshot) return inProcessSnapshot.status
   const live = await getLiveDaemonSnapshot()
   if (live) return live.status
   return buildFallbackStatus()
 }
 
 export async function getDaemonHealthSummarySnapshot(): Promise<DaemonHealthSummaryPayload> {
+  const inProcessSnapshot = getInProcessDaemonSnapshot()
+  if (inProcessSnapshot) return inProcessSnapshot.healthSummary
   const live = await getLiveDaemonSnapshot()
   if (live) return live.healthSummary
   return buildFallbackHealthSummary()
@@ -523,6 +564,8 @@ export async function getDaemonHealthSummarySnapshot(): Promise<DaemonHealthSumm
 
 export async function runDaemonHealthCheckViaAdmin(source: string): Promise<DaemonSnapshotResponse> {
   await ensureDaemonProcessRunning(source, { manualStart: true })
+  const inProcessSnapshot = getInProcessDaemonSnapshot()
+  if (inProcessSnapshot) return inProcessSnapshot
   const metadata = readDaemonAdminMetadata()
   if (!metadata) {
     return {

--- a/src/lib/server/protocols/protocol-agent-turn.test.ts
+++ b/src/lib/server/protocols/protocol-agent-turn.test.ts
@@ -1,0 +1,164 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { runWithTempDataDir } from '@/lib/server/test-utils/run-with-temp-data-dir'
+
+test('defaultExecuteAgentTurn surfaces execution-log errors instead of returning a blank structured response', () => {
+  const output = runWithTempDataDir<{ error: string | null }>(`
+    const storageMod = await import('./src/lib/server/storage')
+    const protocolsMod = await import('./src/lib/server/protocols/protocol-service')
+    const protocolTurnMod = await import('./src/lib/server/protocols/protocol-agent-turn')
+    const streamMod = await import('./src/lib/server/chat-execution/stream-agent-chat')
+    const executionLogMod = await import('./src/lib/server/execution-log')
+
+    const storage = storageMod.default || storageMod
+    const protocols = protocolsMod.default || protocolsMod
+    const { defaultExecuteAgentTurn } = protocolTurnMod.default || protocolTurnMod
+    const { setStreamAgentChatForTest } = streamMod.default || streamMod
+    const { logExecution } = executionLogMod.default || executionLogMod
+
+    storage.upsertStoredItem('agents', 'agentA', {
+      id: 'agentA',
+      name: 'Agent A',
+      provider: 'openai',
+      model: 'gpt-4.1',
+      systemPrompt: 'test',
+      createdAt: 1,
+      updatedAt: 1,
+    })
+
+    const run = protocols.createProtocolRun({
+      title: 'Credential failure run',
+      templateId: 'single_agent_structured_run',
+      participantAgentIds: ['agentA'],
+      facilitatorAgentId: 'agentA',
+      autoStart: false,
+    }, { now: () => 1000 })
+
+    setStreamAgentChatForTest(async (opts) => {
+      logExecution(opts.session.id, 'error', 'Missing credentials. Please pass an apiKey.', {
+        agentId: opts.session.agentId,
+      })
+      return { fullText: '', finalResponse: '', toolEvents: [] }
+    })
+
+    try {
+      await defaultExecuteAgentTurn({
+        run,
+        phase: { id: 'respond', label: 'Respond', kind: 'round_robin' },
+        agentId: 'agentA',
+        prompt: 'Say something useful.',
+      })
+      console.log(JSON.stringify({ error: null }))
+    } catch (error) {
+      console.log(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }))
+    } finally {
+      setStreamAgentChatForTest(null)
+    }
+  `, { prefix: 'swarmclaw-protocol-agent-turn-error-' })
+
+  assert.match(String(output.error || ''), /missing credentials/i)
+})
+
+test('defaultExecuteAgentTurn rejects blank structured responses even without a logged error', () => {
+  const output = runWithTempDataDir<{ error: string | null }>(`
+    const storageMod = await import('./src/lib/server/storage')
+    const protocolsMod = await import('./src/lib/server/protocols/protocol-service')
+    const protocolTurnMod = await import('./src/lib/server/protocols/protocol-agent-turn')
+    const streamMod = await import('./src/lib/server/chat-execution/stream-agent-chat')
+
+    const storage = storageMod.default || storageMod
+    const protocols = protocolsMod.default || protocolsMod
+    const { defaultExecuteAgentTurn } = protocolTurnMod.default || protocolTurnMod
+    const { setStreamAgentChatForTest } = streamMod.default || streamMod
+
+    storage.upsertStoredItem('agents', 'agentA', {
+      id: 'agentA',
+      name: 'Agent A',
+      provider: 'openai',
+      model: 'gpt-4.1',
+      systemPrompt: 'test',
+      createdAt: 1,
+      updatedAt: 1,
+    })
+
+    const run = protocols.createProtocolRun({
+      title: 'Blank response run',
+      templateId: 'single_agent_structured_run',
+      participantAgentIds: ['agentA'],
+      facilitatorAgentId: 'agentA',
+      autoStart: false,
+    }, { now: () => 1000 })
+
+    setStreamAgentChatForTest(async () => ({ fullText: '', finalResponse: '', toolEvents: [] }))
+
+    try {
+      await defaultExecuteAgentTurn({
+        run,
+        phase: { id: 'summarize', label: 'Summarize', kind: 'summarize' },
+        agentId: 'agentA',
+        prompt: 'Summarize.',
+      })
+      console.log(JSON.stringify({ error: null }))
+    } catch (error) {
+      console.log(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }))
+    } finally {
+      setStreamAgentChatForTest(null)
+    }
+  `, { prefix: 'swarmclaw-protocol-agent-turn-blank-' })
+
+  assert.match(String(output.error || ''), /no visible output/i)
+})
+
+test('defaultExecuteAgentTurn uses direct provider runtime for CLI providers', () => {
+  const output = runWithTempDataDir<{ text: string | null }>(`
+    const storageMod = await import('./src/lib/server/storage')
+    const protocolsMod = await import('./src/lib/server/protocols/protocol-service')
+    const protocolTurnMod = await import('./src/lib/server/protocols/protocol-agent-turn')
+    const providersMod = await import('./src/lib/providers/index')
+
+    const storage = storageMod.default || storageMod
+    const protocols = protocolsMod.default || protocolsMod
+    const { defaultExecuteAgentTurn } = protocolTurnMod.default || protocolTurnMod
+    const providers = providersMod.default || providersMod
+
+    storage.upsertStoredItem('agents', 'agentA', {
+      id: 'agentA',
+      name: 'Agent A',
+      provider: 'copilot-cli',
+      model: 'gpt-5.4',
+      systemPrompt: 'test',
+      createdAt: 1,
+      updatedAt: 1,
+    })
+
+    const originalHandler = providers.PROVIDERS['copilot-cli'].handler
+    providers.PROVIDERS['copilot-cli'].handler = {
+      streamChat: async (opts) => {
+        opts.write('data: ' + JSON.stringify({ t: 'd', text: 'Copilot CLI structured response.' }) + '\\n\\n')
+        return 'Copilot CLI structured response.'
+      },
+    }
+
+    const run = protocols.createProtocolRun({
+      title: 'CLI structured run',
+      templateId: 'single_agent_structured_run',
+      participantAgentIds: ['agentA'],
+      facilitatorAgentId: 'agentA',
+      autoStart: false,
+    }, { now: () => 1000 })
+
+    try {
+      const result = await defaultExecuteAgentTurn({
+        run,
+        phase: { id: 'respond', label: 'Respond', kind: 'round_robin' },
+        agentId: 'agentA',
+        prompt: 'Say something useful.',
+      })
+      console.log(JSON.stringify({ text: result.text }))
+    } finally {
+      providers.PROVIDERS['copilot-cli'].handler = originalHandler
+    }
+  `, { prefix: 'swarmclaw-protocol-agent-turn-cli-' })
+
+  assert.equal(output.text, 'Copilot CLI structured response.')
+})

--- a/src/lib/server/protocols/protocol-agent-turn.ts
+++ b/src/lib/server/protocols/protocol-agent-turn.ts
@@ -6,6 +6,8 @@ import { HumanMessage } from '@langchain/core/messages'
 import { z } from 'zod'
 import { log } from '@/lib/server/logger'
 import { genId } from '@/lib/id'
+import { getProvider } from '@/lib/providers'
+import { NON_LANGGRAPH_PROVIDER_IDS } from '@/lib/provider-sets'
 
 const TAG = 'protocol-agent-turn'
 import type {
@@ -49,6 +51,7 @@ import type { ProtocolAgentTurnResult, ProtocolRunDeps } from '@/lib/server/prot
 import { normalizeProtocolRun } from '@/lib/server/protocols/protocol-normalization'
 import { persistChatroomInteractionMemory } from '@/lib/server/chatrooms/chatroom-memory-bridge'
 import { selectKnowledgeCitations } from '@/lib/server/knowledge-sources'
+import { queryLogs } from '@/lib/server/execution-log'
 
 // ---- Zod schema ----
 
@@ -248,24 +251,30 @@ export async function defaultExecuteAgentTurn(params: {
       await new Promise((resolve) => setTimeout(resolve, delay))
     }
     try {
+      const turnStartedAt = Date.now()
+      const history = buildHistoryForAgent(chatroom, agent.id)
       const result = await Promise.race([
-        streamAgentChat({
+        executeStructuredSessionTurn({
           session: syntheticSession,
           message: params.prompt,
           apiKey,
           systemPrompt: fullSystemPrompt,
-          write: () => {},
-          history: buildHistoryForAgent(chatroom, agent.id),
+          history,
         }),
         new Promise<never>((_, reject) =>
           setTimeout(() => reject(new Error(`Agent turn timed out after ${AGENT_TURN_TIMEOUT_MS / 1000}s (agent: ${params.agentId})`)), AGENT_TURN_TIMEOUT_MS),
         ),
       ])
-      const rawText = result.finalResponse || result.fullText || ''
-      const text = stripHiddenControlTokens(rawText)
+      const rawText = result.text || ''
+      const text = resolveStructuredSessionTurnText({
+        rawText,
+        sessionId: syntheticSession.id,
+        turnStartedAt,
+        agentId: params.agentId,
+      })
       const grounding = selectKnowledgeCitations({
         responseText: text,
-        retrievalTrace: result.knowledgeRetrievalTrace || null,
+        retrievalTrace: result.retrievalTrace || null,
       })
       if (text.trim() && !shouldSuppressHiddenControlText(rawText)) {
         appendSyntheticSessionMessage(syntheticSession.id, 'assistant', text)
@@ -295,6 +304,80 @@ export async function defaultExecuteAgentTurn(params: {
     }
   }
   throw lastError
+}
+
+async function executeStructuredSessionTurn(params: {
+  session: ReturnType<typeof ensureSyntheticSession>
+  message: string
+  apiKey: string | null
+  systemPrompt: string
+  history: ReturnType<typeof buildHistoryForAgent>
+}): Promise<ProtocolAgentTurnResult> {
+  if (NON_LANGGRAPH_PROVIDER_IDS.has(params.session.provider)) {
+    const provider = getProvider(params.session.provider)
+    if (!provider) throw new Error(`Unknown provider: ${params.session.provider}`)
+    let streamedText = ''
+    const rawResponseText = await provider.handler.streamChat({
+      session: params.session,
+      message: params.message,
+      apiKey: params.apiKey,
+      systemPrompt: params.systemPrompt,
+      write: (raw: string) => {
+        for (const line of raw.split('\n')) {
+          if (!line.startsWith('data: ')) continue
+          try {
+            const parsed = JSON.parse(line.slice(6).trim()) as { t?: string; text?: string }
+            if ((parsed.t === 'd' || parsed.t === 'r') && typeof parsed.text === 'string') {
+              streamedText += parsed.text
+            }
+          } catch {
+            // Ignore malformed provider event payloads here and fall back to the final response text.
+          }
+        }
+      },
+      active: new Map<string, unknown>(),
+      loadHistory: () => params.history,
+    })
+    return {
+      text: rawResponseText || streamedText,
+      toolEvents: [],
+      retrievalTrace: null,
+      citations: [],
+    }
+  }
+
+  const streamed = await streamAgentChat({
+    session: params.session,
+    message: params.message,
+    apiKey: params.apiKey,
+    systemPrompt: params.systemPrompt,
+    write: () => {},
+    history: params.history,
+  })
+  return {
+    text: streamed.finalResponse || streamed.fullText || '',
+    toolEvents: streamed.toolEvents || [],
+    retrievalTrace: streamed.knowledgeRetrievalTrace || null,
+    citations: [],
+  }
+}
+
+export function resolveStructuredSessionTurnText(params: {
+  rawText: string
+  sessionId: string
+  turnStartedAt: number
+  agentId: string
+}): string {
+  const text = stripHiddenControlTokens(params.rawText)
+  if (text.trim()) return text
+  const recentError = queryLogs({
+    sessionId: params.sessionId,
+    category: 'error',
+    since: params.turnStartedAt,
+    limit: 1,
+  })[0]
+  if (recentError?.summary) throw new Error(recentError.summary)
+  throw new Error(`Structured session turn produced no visible output for agent ${params.agentId}.`)
 }
 
 export function extractFirstJsonObject(text: string): string | null {

--- a/src/lib/server/provider-endpoint.ts
+++ b/src/lib/server/provider-endpoint.ts
@@ -52,9 +52,6 @@ export function resolveProviderCredentialId(input: {
       })[0]?.[0] || normalizedId
   }
 
-  const matchingIds = matchingEntries.map(([id]) => id)
-
-  if (matchingIds.length === 1) return matchingIds[0]
   return normalizedId
 }
 

--- a/src/lib/server/runs/unified-run-records.ts
+++ b/src/lib/server/runs/unified-run-records.ts
@@ -1,0 +1,91 @@
+import type { ProtocolRun, ProtocolRunEvent, RunEventRecord, SessionRunRecord, SessionRunStatus } from '@/types'
+
+function mapProtocolStatus(status: ProtocolRun['status']): SessionRunStatus {
+  switch (status) {
+    case 'draft':
+      return 'queued'
+    case 'running':
+    case 'waiting':
+    case 'paused':
+      return 'running'
+    case 'completed':
+      return 'completed'
+    case 'failed':
+      return 'failed'
+    case 'cancelled':
+    case 'archived':
+      return 'cancelled'
+    default:
+      return 'queued'
+  }
+}
+
+function buildProtocolMessagePreview(run: ProtocolRun): string {
+  return (
+    run.title
+    || run.config?.goal
+    || run.config?.kickoffMessage
+    || run.templateName
+    || 'Structured session run'
+  )
+}
+
+function buildProtocolResultPreview(run: ProtocolRun): string {
+  const summary = typeof run.summary === 'string' ? run.summary.trim() : ''
+  if (summary) return summary
+  const latestArtifact = Array.isArray(run.artifacts)
+    ? [...run.artifacts].sort((left, right) => (right.createdAt || 0) - (left.createdAt || 0))[0]
+    : null
+  const artifactContent = typeof latestArtifact?.content === 'string' ? latestArtifact.content.trim() : ''
+  if (artifactContent) return artifactContent
+  return ''
+}
+
+export function protocolRunToSessionRunRecord(run: ProtocolRun): SessionRunRecord {
+  return {
+    id: run.id,
+    sessionId: run.sessionId || run.transcriptChatroomId || `protocol-run:${run.id}`,
+    kind: 'protocol_step',
+    ownerType: 'protocol_run',
+    ownerId: run.id,
+    source: run.sourceRef.kind === 'schedule' ? 'structured schedule' : 'structured session',
+    internal: run.systemOwned === true,
+    mode: run.templateId,
+    status: mapProtocolStatus(run.status),
+    messagePreview: buildProtocolMessagePreview(run),
+    queuedAt: run.createdAt,
+    startedAt: run.startedAt || undefined,
+    endedAt: run.endedAt || run.archivedAt || undefined,
+    error: run.lastError || undefined,
+    resultPreview: buildProtocolResultPreview(run) || undefined,
+  }
+}
+
+export function protocolEventToRunEventRecord(run: ProtocolRun, event: ProtocolRunEvent): RunEventRecord {
+  const status = event.type === 'failed'
+    ? 'failed'
+    : event.type === 'completed'
+      ? 'completed'
+      : event.type === 'cancelled'
+        ? 'cancelled'
+        : event.type === 'created'
+          ? 'queued'
+          : undefined
+  return {
+    id: event.id,
+    runId: run.id,
+    sessionId: run.sessionId || run.transcriptChatroomId || `protocol-run:${run.id}`,
+    kind: 'protocol_step',
+    ownerType: 'protocol_run',
+    ownerId: run.id,
+    timestamp: event.createdAt,
+    phase: status ? 'status' : 'event',
+    status,
+    summary: event.summary,
+    event: {
+      t: status === 'failed' ? 'err' : 'status',
+      text: event.summary,
+    },
+    citations: event.citations,
+  }
+}

--- a/src/lib/server/runs/unified-run-records.ts
+++ b/src/lib/server/runs/unified-run-records.ts
@@ -83,7 +83,7 @@ export function protocolEventToRunEventRecord(run: ProtocolRun, event: ProtocolR
     status,
     summary: event.summary,
     event: {
-      t: status === 'failed' ? 'err' : 'status',
+      t: status === 'failed' ? 'err' : status ? 'status' : 'md',
       text: event.summary,
     },
     citations: event.citations,

--- a/src/lib/server/schedules/schedule-normalization.ts
+++ b/src/lib/server/schedules/schedule-normalization.ts
@@ -319,7 +319,10 @@ export function normalizeSchedulePayload(payload: SchedulePayload, opts: Normali
         const cronTimezone = trimString(normalized.timezone)
         const interval = CronExpressionParser.parse(
           normalized.cron as string,
-          cronTimezone ? { tz: cronTimezone } : undefined,
+          {
+            ...(cronTimezone ? { tz: cronTimezone } : {}),
+            currentDate: new Date(now),
+          },
         )
         normalized.nextRunAt = applyStagger(interval.next().getTime(), normalized.staggerSec as number | null)
       } catch {

--- a/src/lib/server/schedules/schedule-service.test.ts
+++ b/src/lib/server/schedules/schedule-service.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { prepareScheduleUpdate } from '@/lib/server/schedules/schedule-service'
+import type { Schedule } from '@/types'
+
+function readNextRunAt(value: object): number | undefined {
+  if (!('nextRunAt' in value)) return undefined
+  const nextRunAt = value.nextRunAt
+  return typeof nextRunAt === 'number' ? nextRunAt : undefined
+}
+
+function makeSchedule(overrides: Partial<Schedule> = {}): Schedule {
+  return {
+    id: 'sched-1',
+    name: 'Morning run',
+    agentId: 'agent-1',
+    taskPrompt: 'Do the thing',
+    scheduleType: 'cron',
+    cron: '40 10 * * *',
+    timezone: 'UTC',
+    status: 'active',
+    createdAt: 0,
+    updatedAt: 0,
+    nextRunAt: Date.parse('2026-01-01T10:40:00.000Z'),
+    ...overrides,
+  }
+}
+
+describe('prepareScheduleUpdate', () => {
+  it('recomputes nextRunAt when cron timing changes', () => {
+    const current = makeSchedule()
+    const now = Date.parse('2026-01-01T10:30:00.000Z')
+    const result = prepareScheduleUpdate({
+      id: current.id,
+      current,
+      patch: { cron: '45 10 * * *' },
+      schedules: { [current.id]: current },
+      now,
+    })
+
+    assert.equal(result.ok, true)
+    if (result.ok) {
+      const nextRunAt = readNextRunAt(result.schedule)
+      assert.notEqual(nextRunAt, current.nextRunAt)
+      assert.equal(typeof nextRunAt, 'number')
+      assert.ok((nextRunAt || 0) > Date.now())
+    }
+  })
+
+  it('recomputes nextRunAt when reactivating a paused interval schedule', () => {
+    const current = makeSchedule({
+      scheduleType: 'interval',
+      cron: undefined,
+      intervalMs: 300_000,
+      status: 'paused',
+      nextRunAt: 123,
+    })
+    const now = 1_000_000
+    const result = prepareScheduleUpdate({
+      id: current.id,
+      current,
+      patch: { status: 'active' },
+      schedules: { [current.id]: current },
+      now,
+    })
+
+    assert.equal(result.ok, true)
+    if (result.ok) {
+      assert.equal(readNextRunAt(result.schedule), 1_300_000)
+    }
+  })
+})

--- a/src/lib/server/schedules/schedule-service.test.ts
+++ b/src/lib/server/schedules/schedule-service.test.ts
@@ -44,7 +44,7 @@ describe('prepareScheduleUpdate', () => {
       const nextRunAt = readNextRunAt(result.schedule)
       assert.notEqual(nextRunAt, current.nextRunAt)
       assert.equal(typeof nextRunAt, 'number')
-      assert.ok((nextRunAt || 0) > Date.now())
+      assert.equal(nextRunAt, Date.parse('2026-01-01T10:45:00.000Z'))
     }
   })
 

--- a/src/lib/server/schedules/schedule-service.ts
+++ b/src/lib/server/schedules/schedule-service.ts
@@ -211,10 +211,17 @@ export type PrepareScheduleUpdateResult =
     }
 
 export function prepareScheduleUpdate(options: PrepareScheduleUpdateOptions): PrepareScheduleUpdateResult {
+  const nextStatus = normalizeScheduleStatus(options.patch.status)
+  const shouldRecomputeNextRunAt = !('nextRunAt' in options.patch) && (
+    ['scheduleType', 'cron', 'intervalMs', 'runAt', 'timezone', 'staggerSec']
+      .some((key) => key in options.patch)
+    || (nextStatus === 'active' && options.current.status !== 'active')
+  )
   const normalized = normalizeSchedulePayload({
     ...options.current,
     ...options.patch,
     id: options.id,
+    ...(shouldRecomputeNextRunAt ? { nextRunAt: undefined } : {}),
   }, {
     cwd: options.cwd,
     now: options.now,
@@ -237,8 +244,8 @@ export function prepareScheduleUpdate(options: PrepareScheduleUpdateOptions): Pr
   })
 
   const entries: Array<[string, ScheduleLike]> = [[options.id, nextSchedule]]
-  const nextStatus = normalizeScheduleStatus(nextSchedule.status)
-  if (options.propagateEquivalentStatuses && (nextStatus === 'paused' || nextStatus === 'completed' || nextStatus === 'failed' || nextStatus === 'archived')) {
+  const normalizedStatus = normalizeScheduleStatus(nextSchedule.status)
+  if (options.propagateEquivalentStatuses && (normalizedStatus === 'paused' || normalizedStatus === 'completed' || normalizedStatus === 'failed' || normalizedStatus === 'archived')) {
     const relatedIds = findRelatedScheduleIds(
       options.schedules,
       options.propagationSource || options.current,
@@ -249,7 +256,7 @@ export function prepareScheduleUpdate(options: PrepareScheduleUpdateOptions): Pr
       if (!related) continue
       entries.push([relatedId, {
         ...related,
-        status: nextStatus,
+        status: normalizedStatus,
         updatedAt: options.now,
       }])
     }


### PR DESCRIPTION
## Summary
- surface structured schedule protocol runs in the schedule console and unified runs APIs
- fix structured session execution for CLI providers and surface blank-output failures
- add a real new-chat flow for agent sessions, keep the first user message visible, and derive titles from the opening prompt

## Validation
- npm run type-check
- npm run build
- focused node --test suites for protocol runs, clear/new-session helpers, and related route coverage