### PR TITLE
Fix browser MCP standalone runtime

### DIFF
--- a/scripts/run-next-build.mjs
+++ b/scripts/run-next-build.mjs
@@ -35,6 +35,11 @@ export const REQUIRED_NEXT_METADATA_FILES = [
   'get-metadata-route.js',
   'is-metadata-route.js',
 ]
+export const REQUIRED_STANDALONE_BROWSER_PACKAGES = [
+  '@playwright/mcp',
+  'playwright',
+  'playwright-core',
+]
 
 function parsePositiveInteger(value) {
   const parsed = Number.parseInt(String(value ?? '').trim(), 10)
@@ -187,6 +192,28 @@ export function repairStandaloneCssTreeData(cwd = process.cwd()) {
   return repaired
 }
 
+export function repairStandaloneBrowserMcpRuntime(cwd = process.cwd()) {
+  const standaloneDir = path.join(cwd, '.next', 'standalone')
+  if (!fs.existsSync(standaloneDir)) return false
+
+  let repaired = false
+  const standaloneNodeModules = path.join(standaloneDir, 'node_modules')
+  for (const packageName of REQUIRED_STANDALONE_BROWSER_PACKAGES) {
+    const sourceDir = path.join(cwd, 'node_modules', ...packageName.split('/'))
+    const targetDir = path.join(standaloneNodeModules, ...packageName.split('/'))
+    if (fs.existsSync(targetDir)) continue
+    if (!fs.existsSync(sourceDir)) {
+      throw new Error(`Missing required browser MCP runtime package under ${sourceDir}.`)
+    }
+
+    fs.mkdirSync(path.dirname(targetDir), { recursive: true })
+    fs.cpSync(sourceDir, targetDir, { recursive: true, force: true })
+    repaired = true
+  }
+
+  return repaired
+}
+
 export function repairStandaloneNextMetadata(cwd = process.cwd()) {
   const standaloneDir = path.join(cwd, '.next', 'standalone')
   if (!fs.existsSync(standaloneDir)) return false
@@ -247,6 +274,9 @@ function main() {
     }
     if (result.status === 0 && repairStandaloneCssTreeData(process.cwd())) {
       console.error('Copied css-tree/data/ into standalone build output.')
+    }
+    if (result.status === 0 && repairStandaloneBrowserMcpRuntime(process.cwd())) {
+      console.error('Copied Playwright MCP runtime packages into standalone build output.')
     }
     process.exit(result.status)
   }

--- a/scripts/run-next-build.test.mjs
+++ b/scripts/run-next-build.test.mjs
@@ -10,10 +10,12 @@ import {
   DEFAULT_MAX_OLD_SPACE_SIZE_MB,
   NEXT_STANDALONE_METADATA_RELATIVE_DIR,
   REQUIRED_NEXT_METADATA_FILES,
+  REQUIRED_STANDALONE_BROWSER_PACKAGES,
   buildNextBuildEnv,
   deriveMaxOldSpaceSizeMb,
   hasTraceCopyWarning,
   mergeNodeOptions,
+  repairStandaloneBrowserMcpRuntime,
   readCgroupMemoryLimitBytes,
   repairStandaloneCssTreeData,
   repairStandaloneNextMetadata,
@@ -197,6 +199,43 @@ describe('run-next-build', () => {
       const standaloneNm = path.join(tempDir, '.next', 'standalone', 'node_modules')
       assert.equal(fs.existsSync(path.join(standaloneNm, 'css-tree', 'data', 'patch.json')), true)
       assert.equal(fs.existsSync(path.join(standaloneNm, 'mdn-data', 'css', 'at-rules.json')), true)
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('repairStandaloneBrowserMcpRuntime copies Playwright MCP runtime packages into standalone output', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'swarmclaw-browser-mcp-'))
+    try {
+      fs.mkdirSync(path.join(tempDir, '.next', 'standalone'), { recursive: true })
+      for (const packageName of REQUIRED_STANDALONE_BROWSER_PACKAGES) {
+        const packageDir = path.join(tempDir, 'node_modules', ...packageName.split('/'))
+        fs.mkdirSync(packageDir, { recursive: true })
+        fs.writeFileSync(path.join(packageDir, 'package.json'), `{"name":${JSON.stringify(packageName)}}`)
+      }
+      fs.writeFileSync(
+        path.join(tempDir, 'node_modules', '@playwright', 'mcp', 'cli.js'),
+        '#!/usr/bin/env node\n',
+      )
+
+      const repaired = repairStandaloneBrowserMcpRuntime(tempDir)
+      assert.equal(repaired, true)
+
+      for (const packageName of REQUIRED_STANDALONE_BROWSER_PACKAGES) {
+        const targetPackageJson = path.join(
+          tempDir,
+          '.next',
+          'standalone',
+          'node_modules',
+          ...packageName.split('/'),
+          'package.json',
+        )
+        assert.equal(fs.existsSync(targetPackageJson), true)
+      }
+      assert.equal(
+        fs.existsSync(path.join(tempDir, '.next', 'standalone', 'node_modules', '@playwright', 'mcp', 'cli.js')),
+        true,
+      )
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true })
     }

--- a/src/lib/server/session-tools/web-browser-config.test.ts
+++ b/src/lib/server/session-tools/web-browser-config.test.ts
@@ -18,9 +18,12 @@ describe('browser tool connection config', () => {
     const params = buildBrowserStdioServerParams('/tmp/swarmclaw-browser-profile')
 
     assert.equal(params.command, process.execPath)
+    assert.equal(params.args.includes('--browser'), true)
+    assert.equal(params.args.includes('chromium'), true)
     assert.equal(params.args.includes('--headless'), true)
     assert.equal(params.args.includes('--shared-browser-context'), false)
     assert.equal(params.args.includes('/tmp/swarmclaw-browser-profile'), true)
+    assert.equal((params.env as Record<string, string | undefined>).PLAYWRIGHT_MCP_BROWSER, 'chromium')
     assert.equal((params.env as Record<string, string | undefined>).PLAYWRIGHT_MCP_USER_DATA_DIR, '/tmp/swarmclaw-browser-profile')
     assert.equal(params.env.PLAYWRIGHT_MCP_OUTPUT_MODE, 'file')
     assert.equal(params.env.PLAYWRIGHT_MCP_TIMEOUT_ACTION, '60000')
@@ -39,10 +42,12 @@ describe('browser tool connection config', () => {
     assert.equal(params.args.includes('--cdp-header'), true)
     assert.equal(params.args.includes('Authorization: Bearer token-123'), true)
     assert.equal(params.args.includes('--allow-unrestricted-file-access'), true)
+    assert.equal(params.args.includes('--browser'), false)
     assert.equal(params.args.includes('--user-data-dir'), false)
     const env = params.env as Record<string, string | undefined>
     assert.equal(env.PLAYWRIGHT_MCP_CDP_ENDPOINT, 'http://127.0.0.1:44001')
     assert.equal(params.env.PLAYWRIGHT_MCP_ALLOW_UNRESTRICTED_FILE_ACCESS, '1')
+    assert.equal(env.PLAYWRIGHT_MCP_BROWSER, undefined)
     assert.equal(env.PLAYWRIGHT_MCP_USER_DATA_DIR, undefined)
   })
 

--- a/src/lib/server/session-tools/web-utils.ts
+++ b/src/lib/server/session-tools/web-utils.ts
@@ -134,6 +134,7 @@ export function buildBrowserStdioServerParams(
     }
   } else {
     args.push(
+      '--browser', 'chromium',
       '--headless',
       '--user-data-dir', profileDir,
     )
@@ -145,6 +146,7 @@ export function buildBrowserStdioServerParams(
     env: {
       ...env,
       ...(cdpEndpoint ? { PLAYWRIGHT_MCP_CDP_ENDPOINT: cdpEndpoint } : {
+        PLAYWRIGHT_MCP_BROWSER: 'chromium',
         PLAYWRIGHT_MCP_USER_DATA_DIR: profileDir,
         PLAYWRIGHT_MCP_HEADLESS: '1',
       }),


### PR DESCRIPTION
## Summary
- copy Playwright MCP runtime packages into Next standalone output
- launch host Playwright MCP with cached chromium instead of system Chrome
- add tests for standalone packaging and browser startup args

## Tests
- npm run test:cli -- scripts/run-next-build.test.mjs
- npx tsx --test src/lib/server/session-tools/web-browser-config.test.ts
- npm run build