### PR TITLE
Fix opencode-cli hang from connected stdin pipe

### DIFF
--- a/src/lib/providers/opencode-cli.ts
+++ b/src/lib/providers/opencode-cli.ts
@@ -60,7 +60,9 @@ export function streamOpenCodeCliChat({ session, message, imagePath, systemPromp
   const proc = spawn(binary, args, {
     cwd,
     env,
-    stdio: ['pipe', 'pipe', 'pipe'],
+    // stdin must be 'ignore' (not 'pipe'): OpenCode CLI hangs forever waiting on stdin
+    // if it's a connected pipe that's never closed, even when the prompt is passed via argv.
+    stdio: ['ignore', 'pipe', 'pipe'],
     timeout: processTimeoutMs,
   })
 


### PR DESCRIPTION
## Summary

`streamOpenCodeCliChat` spawns the OpenCode CLI with `stdio: ['pipe', 'pipe', 'pipe']`. The child inherits a stdin pipe that SwarmClaw never writes to and never closes — and OpenCode CLI blocks reading stdin even when the prompt is supplied via argv. The result is that every chat request hangs until the SwarmClaw-side process timeout fires; nothing ever streams back.

Switching stdin to `'ignore'` gives the child a closed input fd, so it proceeds to consume the argv prompt and stream output normally. stdout/stderr stay on pipes.

Reproduced on a deployed instance (provider `opencode-cli`, model `kimi-code/kimi-for-coding`): every send timed out with `'pipe'`, every send streamed normally with `'ignore'`.

## Test plan

- [ ] Configure an `opencode-cli` provider and send a chat message — response streams instead of hanging
- [ ] Existing providers (claude-cli, anthropic, openrouter, etc.) unaffected (change is scoped to `opencode-cli.ts`)