### PR TITLE
Fix codex session continuity and active session selection UX

### DIFF
--- a/bin/swarmclaw.js
+++ b/bin/swarmclaw.js
@@ -3,6 +3,8 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 
 const path = require('node:path')
+const fs = require('node:fs')
+const os = require('node:os')
 const { spawnSync } = require('node:child_process')
 
 // Legacy TS CLI groups/actions that provide richer, command-specific options.
@@ -142,6 +144,79 @@ Show the installed SwarmClaw package version.
 `.trim() + '\n')
 }
 
+function readUserServiceSwarmclawHome() {
+  const homeDir = process.env.HOME || os.homedir()
+  const servicePath = path.join(homeDir, '.config', 'systemd', 'user', 'swarmclaw.service')
+  try {
+    const text = fs.readFileSync(servicePath, 'utf8')
+    const lines = text.split(/\r?\n/)
+    for (const line of lines) {
+      const trimmed = line.trim()
+      if (!trimmed.startsWith('Environment=')) continue
+      let value = trimmed.slice('Environment='.length).trim()
+      if (value.startsWith('"') && value.endsWith('"')) {
+        value = value.slice(1, -1)
+      }
+      if (!value.startsWith('SWARMCLAW_HOME=')) continue
+      const homeValue = value.slice('SWARMCLAW_HOME='.length).trim()
+      if (homeValue) return homeValue
+    }
+  } catch {
+    return null
+  }
+  return null
+}
+
+function getUserServicePath() {
+  const homeDir = process.env.HOME || os.homedir()
+  return path.join(homeDir, '.config', 'systemd', 'user', 'swarmclaw.service')
+}
+
+function hasUserSystemdService() {
+  return fs.existsSync(getUserServicePath())
+}
+
+function runSystemctlUser(args) {
+  return spawnSync('systemctl', ['--user', ...args], { stdio: 'inherit', env: process.env })
+}
+
+function hasServerLifecycleFlags(argv) {
+  return argv.some((arg) => (
+    arg === '--build'
+    || arg === '-d'
+    || arg === '--detach'
+    || arg === '--port'
+    || arg === '--ws-port'
+    || arg === '--host'
+  ))
+}
+
+function handleServiceLifecycle(top, argv) {
+  // If the user passed host/port/build flags, fall back to local server-cmd behavior.
+  const hasServerFlags = hasServerLifecycleFlags(argv)
+  if (hasServerFlags || !hasUserSystemdService()) return false
+
+  const unit = 'swarmclaw.service'
+  if (top === 'run' || top === 'start') {
+    const started = runSystemctlUser(['start', unit])
+    if (typeof started.status === 'number') process.exitCode = started.status
+    return true
+  }
+  if (top === 'stop') {
+    const stopped = runSystemctlUser(['stop', unit])
+    if (typeof stopped.status === 'number') process.exitCode = stopped.status
+    return true
+  }
+
+  return false
+}
+
+function applyServiceHomeDefault() {
+  if (typeof process.env.SWARMCLAW_HOME === 'string' && process.env.SWARMCLAW_HOME.trim()) return
+  const serviceHome = readUserServiceSwarmclawHome()
+  if (serviceHome) process.env.SWARMCLAW_HOME = serviceHome
+}
+
 async function runMappedCli(argv) {
   const cliPath = path.join(__dirname, '..', 'src', 'cli', 'index.js')
   const cliModule = await import(cliPath)
@@ -196,6 +271,8 @@ async function runHelp(argv) {
 }
 
 async function main() {
+  applyServiceHomeDefault()
+
   const argv = process.argv.slice(2)
   const top = argv[0]
 
@@ -233,10 +310,20 @@ async function main() {
     }
   }
   if (top === 'run' || top === 'start') {
+    if (handleServiceLifecycle(top, argv.slice(1))) return
     await require('./server-cmd.js').main(argv.slice(1))
     return
   }
   if (top === 'status' || top === 'stop') {
+    if (top === 'status' && hasUserSystemdService() && !hasServerLifecycleFlags(argv.slice(1))) {
+      const serviceStatus = runSystemctlUser(['status', 'swarmclaw.service', '--no-pager'])
+      const apiStatusCode = await runMappedCli(['system-status', 'get'])
+      const serviceCode = typeof serviceStatus.status === 'number' ? serviceStatus.status : 1
+      const apiCode = typeof apiStatusCode === 'number' ? apiStatusCode : 1
+      process.exitCode = serviceCode !== 0 ? serviceCode : apiCode
+      return
+    }
+    if (handleServiceLifecycle(top, argv.slice(1))) return
     await require('./server-cmd.js').main([top, ...argv.slice(1)])
     return
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4917,9 +4917,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4935,9 +4932,6 @@
       "integrity": "sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4955,9 +4949,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4974,9 +4965,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4992,9 +4980,6 @@
       "integrity": "sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5705,9 +5690,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5727,9 +5709,6 @@
       "integrity": "sha512-kKmSkQVnWeqg7qdsiXvYxKhAFuHz3tkBjW/zyQv5YKUPhotpaVhpBGv5LqCngzyuRV85SXoe+OFj+Tv0a0QXkQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5751,9 +5730,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5774,9 +5750,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5796,9 +5769,6 @@
       "integrity": "sha512-AKLFd/v0Z5fvgqBDqhvqtAdx+fHMJ5t9JcUNKq4FIZ5WH+iegGm8HPdj00NFlCSnm83Fp3Ln8I2f7uq1aIiWaA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5921,9 +5891,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5939,9 +5906,6 @@
       "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5959,9 +5923,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5977,9 +5938,6 @@
       "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1001,8 +1001,14 @@ function resolveAccessKey(opts, env, cwd) {
   const envKey = env.SWARMCLAW_API_KEY || env.SC_ACCESS_KEY || env.SWARMCLAW_ACCESS_KEY || ''
   if (envKey) return String(envKey).trim()
 
-  const keyFile = path.join(cwd, 'platform-api-key.txt')
-  if (fs.existsSync(keyFile)) {
+  const keyLocations = [
+    path.join(cwd, 'platform-api-key.txt'),
+  ]
+  const homeDir = String(env.SWARMCLAW_HOME || '').trim()
+  if (homeDir) keyLocations.push(path.join(homeDir, 'platform-api-key.txt'))
+
+  for (const keyFile of keyLocations) {
+    if (!fs.existsSync(keyFile)) continue
     const content = fs.readFileSync(keyFile, 'utf8').trim()
     if (content) return content
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -45,9 +45,18 @@ function resolveDefaultAccessKey(cwd: string = process.cwd()): string {
   ).trim()
   if (envKey) return envKey
 
-  const keyFile = path.join(cwd, 'platform-api-key.txt')
-  if (!fs.existsSync(keyFile)) return ''
-  return fs.readFileSync(keyFile, 'utf8').trim()
+  const keyLocations = [
+    path.join(cwd, 'platform-api-key.txt'),
+  ]
+  const serviceHome = (process.env.SWARMCLAW_HOME || '').trim()
+  if (serviceHome) keyLocations.push(path.join(serviceHome, 'platform-api-key.txt'))
+
+  for (const keyFile of keyLocations) {
+    if (!fs.existsSync(keyFile)) continue
+    const value = fs.readFileSync(keyFile, 'utf8').trim()
+    if (value) return value
+  }
+  return ''
 }
 
 const DEFAULT_ACCESS_KEY = resolveDefaultAccessKey()

--- a/src/components/agents/inspector-panel.tsx
+++ b/src/components/agents/inspector-panel.tsx
@@ -4,9 +4,9 @@ import { DEFAULT_HEARTBEAT_INTERVAL_SEC } from '@/lib/runtime/heartbeat-defaults
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import type { Agent, MemoryEntry, Session } from '@/types'
 import { useAppStore } from '@/stores/use-app-store'
+import { selectActiveSessionId } from '@/stores/slices/session-slice'
 import { useChatStore } from '@/stores/use-chat-store'
 import { api } from '@/lib/app/api-client'
-import { sortSessionsNewestFirst } from '@/lib/chat/new-session'
 import { AgentAvatar } from './agent-avatar'
 import { AgentFilesEditor } from './agent-files-editor'
 import { OpenClawSkillsPanel } from './openclaw-skills-panel'
@@ -901,6 +901,7 @@ function QuickActionsSection({ agent, session }: { agent: Agent; session: Sessio
 
 function SessionsSection({ agent }: { agent: Agent }) {
   const sessions = useAppStore((s) => s.sessions)
+  const activeSessionId = useAppStore(selectActiveSessionId)
   const connectors = useAppStore((s) => s.connectors)
   const agents = useAppStore((s) => s.agents)
   const setCurrentAgent = useAppStore((s) => s.setCurrentAgent)
@@ -908,7 +909,19 @@ function SessionsSection({ agent }: { agent: Agent }) {
   const setInspectorOpen = useAppStore((s) => s.setInspectorOpen)
 
   const agentSessions = useMemo(() => {
-    return sortSessionsNewestFirst(Object.values(sessions).filter((s) => s.agentId === agent.id))
+    const getLastMessageTime = (session: Session): number => {
+      const summaryTime = session.lastMessageSummary?.time
+      if (typeof summaryTime === 'number' && Number.isFinite(summaryTime)) return summaryTime
+      if (Array.isArray(session.messages) && session.messages.length > 0) {
+        const last = session.messages[session.messages.length - 1]
+        if (typeof last?.time === 'number' && Number.isFinite(last.time)) return last.time
+      }
+      return session.lastActiveAt || session.createdAt || 0
+    }
+
+    return Object.values(sessions)
+      .filter((s) => s.agentId === agent.id)
+      .sort((left, right) => getLastMessageTime(right) - getLastMessageTime(left))
   }, [sessions, agent.id])
 
   if (agentSessions.length === 0) return null
@@ -918,6 +931,7 @@ function SessionsSection({ agent }: { agent: Agent }) {
       <SectionLabel>Sessions ({agentSessions.length})</SectionLabel>
       <div className="flex flex-col gap-1.5">
         {agentSessions.map((s) => {
+          const isSelected = s.id === activeSessionId
           const connector = getSessionConnector(s, connectors)
           const delegatedByAgentId = (s as unknown as Record<string, unknown>).delegatedByAgentId as string | undefined
           const delegatedBy = delegatedByAgentId ? agents[delegatedByAgentId] : null
@@ -934,7 +948,10 @@ function SessionsSection({ agent }: { agent: Agent }) {
                   }
                 }).catch(() => {})
               }}
-              className="flex items-center gap-2 w-full py-1.5 px-2 rounded-[8px] bg-transparent border-none cursor-pointer hover:bg-white/[0.04] transition-colors text-left"
+              className={`flex items-center gap-2 w-full py-1.5 px-2 rounded-[8px] border-none cursor-pointer transition-colors text-left
+                ${isSelected
+                  ? 'bg-accent-soft/70 ring-1 ring-accent-bright/25'
+                  : 'bg-transparent hover:bg-white/[0.04]'}`}
             >
               {connector ? (
                 <ConnectorPlatformIcon platform={connector.platform} size={14} />
@@ -944,6 +961,11 @@ function SessionsSection({ agent }: { agent: Agent }) {
                 </svg>
               )}
               <span className="text-[12px] text-text-2 truncate flex-1">{s.name}</span>
+              {isSelected && (
+                <span className="text-[9px] font-700 uppercase tracking-[0.08em] text-accent-bright bg-accent-bright/15 px-1.5 py-0.5 rounded-[6px] shrink-0">
+                  Selected
+                </span>
+              )}
               {delegatedBy && (
                 <span className="text-[9px] text-amber-300/60 font-600 shrink-0">from {delegatedBy.name}</span>
               )}

--- a/src/components/chat/chat-card.tsx
+++ b/src/components/chat/chat-card.tsx
@@ -143,6 +143,11 @@ export function ChatCard({ session, active, onClick }: Props) {
           />
         )}
         <span className="font-display text-[14px] font-600 truncate flex-1 tracking-[-0.01em]">{displayName}</span>
+        {active && (
+          <span className="shrink-0 text-[9px] font-700 uppercase tracking-[0.08em] text-accent-bright bg-accent-bright/15 px-1.5 py-0.5 rounded-[6px]">
+            Selected
+          </span>
+        )}
         {providerLabel && (
           <span className="shrink-0 text-[10px] font-600 uppercase tracking-wider text-text-3/70 bg-white/[0.03] px-2 py-0.5 rounded-[6px]">
             {providerLabel}

--- a/src/lib/providers/cli-utils.test.ts
+++ b/src/lib/providers/cli-utils.test.ts
@@ -1,7 +1,17 @@
 import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import { describe, it } from 'node:test'
 
-import { isStderrNoise, buildCliEnv, isCliProvider, CLI_PROVIDER_CAPABILITIES } from './cli-utils'
+import {
+  isStderrNoise,
+  buildCliEnv,
+  isCliProvider,
+  CLI_PROVIDER_CAPABILITIES,
+  resolveCodexProbeInvocation,
+  ensureCliWorkingDirectory,
+} from './cli-utils'
 
 // ---------------------------------------------------------------------------
 // isStderrNoise
@@ -130,5 +140,59 @@ describe('CLI_PROVIDER_CAPABILITIES', () => {
       assert.equal(typeof value, 'string', `${key} should be a string`)
       assert.ok(value.length > 0, `${key} should be non-empty`)
     }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveCodexProbeInvocation
+// ---------------------------------------------------------------------------
+
+describe('resolveCodexProbeInvocation', () => {
+  it('uses node directly for codex JS wrappers discovered through a symlink', () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'swarmclaw-codex-probe-'))
+    try {
+      const realScript = path.join(tmpRoot, 'codex.js')
+      fs.writeFileSync(realScript, '#!/usr/bin/env node\nconsole.log("ok")\n')
+      fs.chmodSync(realScript, 0o755)
+
+      const wrapperPath = path.join(tmpRoot, 'codex')
+      fs.symlinkSync(realScript, wrapperPath)
+
+      const invocation = resolveCodexProbeInvocation(wrapperPath)
+      assert.equal(invocation.command, process.execPath)
+      assert.deepEqual(invocation.args, [realScript, 'login', 'status'])
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('uses the binary directly for non-JS executables', () => {
+    const invocation = resolveCodexProbeInvocation('/usr/local/bin/codex-bin')
+    assert.equal(invocation.command, '/usr/local/bin/codex-bin')
+    assert.deepEqual(invocation.args, ['login', 'status'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ensureCliWorkingDirectory
+// ---------------------------------------------------------------------------
+
+describe('ensureCliWorkingDirectory', () => {
+  it('creates a missing working directory recursively', () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'swarmclaw-cli-cwd-'))
+    const target = path.join(tmpRoot, 'nested', 'room')
+    try {
+      assert.equal(fs.existsSync(target), false)
+      const resolved = ensureCliWorkingDirectory(target)
+      assert.equal(resolved, target)
+      assert.equal(fs.existsSync(target), true)
+      assert.equal(fs.statSync(target).isDirectory(), true)
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('falls back to process.cwd when cwd is blank', () => {
+    assert.equal(ensureCliWorkingDirectory(''), process.cwd())
   })
 })

--- a/src/lib/providers/cli-utils.ts
+++ b/src/lib/providers/cli-utils.ts
@@ -10,6 +10,7 @@ import os from 'os'
 import { findBinaryOnPath } from '../server/session-tools/context'
 import path from 'path'
 import { spawnSync, type ChildProcess } from 'child_process'
+import { realpathSync } from 'fs'
 import { log } from '../server/logger'
 
 // ---------------------------------------------------------------------------
@@ -168,6 +169,25 @@ export interface AuthProbeResult {
   errorMessage?: string
 }
 
+export function resolveCodexProbeInvocation(binary: string): { command: string; args: string[] } {
+  try {
+    const resolved = realpathSync(binary)
+    if (resolved.toLowerCase().endsWith('.js')) {
+      return { command: process.execPath, args: [resolved, 'login', 'status'] }
+    }
+  } catch {
+    // Fall through to direct execution when the binary cannot be resolved.
+  }
+
+  return { command: binary, args: ['login', 'status'] }
+}
+
+export function ensureCliWorkingDirectory(cwd?: string | null): string {
+  const resolved = typeof cwd === 'string' && cwd.trim() ? cwd.trim() : process.cwd()
+  fs.mkdirSync(resolved, { recursive: true })
+  return resolved
+}
+
 /**
  * Unified auth check for supported CLI-backed providers.
  */
@@ -198,7 +218,8 @@ export function probeCliAuth(
   }
 
   if (backend === 'codex') {
-    const probe = spawnSync(binary, ['login', 'status'], {
+    const invocation = resolveCodexProbeInvocation(binary)
+    const probe = spawnSync(invocation.command, invocation.args, {
       cwd, env, encoding: 'utf-8', timeout: 8000,
     })
     const probeText = `${probe.stdout || ''}\n${probe.stderr || ''}`.toLowerCase()

--- a/src/lib/providers/codex-cli.ts
+++ b/src/lib/providers/codex-cli.ts
@@ -27,10 +27,19 @@ export function streamCodexCliChat({ session, message, imagePath, systemPrompt, 
 
   const prompt = message
   const args: string[] = ['exec']
+  // Use ~/.codex-sessions/ not /tmp — codex refuses to create helper binaries under /tmp
+  const sessionsDir = path.join(os.homedir(), '.codex-sessions')
+  const perSessionHome = path.join(sessionsDir, session.id)
+  const hasPerSessionHome = fs.existsSync(perSessionHome)
 
   // Session resume
-  if (session.codexThreadId) {
+  if (session.codexThreadId && hasPerSessionHome) {
     args.push('resume', session.codexThreadId)
+  } else if (session.codexThreadId && !hasPerSessionHome) {
+    // Legacy recovery: older builds removed per-session CODEX_HOME on each turn.
+    // If we still have a thread id but no local metadata, force a fresh thread.
+    log.warn('codex-cli', `Missing session home for stored thread; resetting resume state for ${session.id}`)
+    session.codexThreadId = null
   }
 
   // Use --dangerously-bypass-approvals-and-sandbox instead of --full-auto so that
@@ -69,25 +78,24 @@ export function streamCodexCliChat({ session, message, imagePath, systemPrompt, 
     }
   }
 
-  // System prompt + MCP injection: create a temp CODEX_HOME when needed
-  // Symlink auth files from the real config dir so auth still works
-  let tempCodexHome: string | null = null
+  // System prompt + MCP injection: create/use a stable per-session CODEX_HOME
+  // when needed. This must persist across turns so `codex exec resume <thread_id>`
+  // can access local thread metadata.
+  let sessionCodexHome: string | null = null
   const agentForMcp = session.agentId ? getAgent(session.agentId as string) : null
   const agentMcpServerIds: string[] = agentForMcp?.mcpServerIds || []
-  const needsTempHome = (systemPrompt && !session.codexThreadId) || agentMcpServerIds.length > 0
-  if (needsTempHome) {
-    const realCodexHome = process.env.CODEX_HOME || path.join(os.homedir(), '.codex')
-    // Use ~/.codex-sessions/ not /tmp — codex refuses to create helper binaries under /tmp
-    const sessionsDir = path.join(os.homedir(), '.codex-sessions')
-    tempCodexHome = path.join(sessionsDir, session.id)
-    fs.mkdirSync(tempCodexHome, { recursive: true })
+  const realCodexHome = process.env.CODEX_HOME || path.join(os.homedir(), '.codex')
+  const needsSessionHome = hasPerSessionHome || ((systemPrompt && !session.codexThreadId) || agentMcpServerIds.length > 0)
+  if (needsSessionHome) {
+    sessionCodexHome = perSessionHome
+    fs.mkdirSync(sessionCodexHome, { recursive: true })
 
-    // Symlink auth/config files from real CODEX_HOME into temp dir
-    symlinkConfigFiles(realCodexHome, tempCodexHome)
+    // Symlink auth/config files from real CODEX_HOME into session dir
+    symlinkConfigFiles(realCodexHome, sessionCodexHome)
 
     // Write system prompt as AGENTS.override.md (first turn only)
     if (systemPrompt && !session.codexThreadId) {
-      fs.writeFileSync(path.join(tempCodexHome, 'AGENTS.override.md'), systemPrompt)
+      fs.writeFileSync(path.join(sessionCodexHome, 'AGENTS.override.md'), systemPrompt)
     }
 
     // Inject agent-assigned MCP servers into config.toml
@@ -125,7 +133,7 @@ export function streamCodexCliChat({ session, message, imagePath, systemPrompt, 
           const existingConfig = fs.existsSync(realConfigPath)
             ? fs.readFileSync(realConfigPath, 'utf-8')
             : ''
-          const tempConfigPath = path.join(tempCodexHome, 'config.toml')
+          const tempConfigPath = path.join(sessionCodexHome, 'config.toml')
           // Remove symlink created by symlinkConfigFiles before writing our own file
           try { fs.unlinkSync(tempConfigPath) } catch { /* no symlink — ignore */ }
           fs.writeFileSync(tempConfigPath, existingConfig + '\n' + tomlParts.join('\n'))
@@ -136,7 +144,7 @@ export function streamCodexCliChat({ session, message, imagePath, systemPrompt, 
       }
     }
 
-    env.CODEX_HOME = tempCodexHome
+    env.CODEX_HOME = sessionCodexHome
   }
 
   log.info('codex-cli', `Spawning: ${binary}`, {
@@ -144,7 +152,7 @@ export function streamCodexCliChat({ session, message, imagePath, systemPrompt, 
     cwd: session.cwd,
     promptLen: prompt.length,
     hasSystemPrompt: !!systemPrompt,
-    tempCodexHome,
+    sessionCodexHome,
   })
 
   const proc = spawn(binary, args, {
@@ -185,9 +193,14 @@ export function streamCodexCliChat({ session, message, imagePath, systemPrompt, 
         eventCount++
 
         // Track thread ID for session resume
-        if (ev.type === 'thread.started' && ev.thread_id) {
-          session.codexThreadId = ev.thread_id
-          log.info('codex-cli', `Got thread_id: ${ev.thread_id}`)
+        const threadId = typeof ev.thread_id === 'string'
+          ? ev.thread_id
+          : (typeof ev.thread?.id === 'string' ? ev.thread.id : null)
+        if (threadId) {
+          session.codexThreadId = threadId
+          if (eventCount <= 3 || ev.type === 'thread.started') {
+            log.info('codex-cli', `Got thread_id: ${threadId} (${ev.type})`)
+          }
         }
 
         // Streaming text deltas (if codex adds streaming support)
@@ -269,10 +282,6 @@ export function streamCodexCliChat({ session, message, imagePath, systemPrompt, 
     proc.on('close', (code, sig) => {
       log.info('codex-cli', `Process closed: code=${code} signal=${sig} events=${eventCount} response=${fullResponse.length}chars`)
       active.delete(session.id)
-      // Clean up temp CODEX_HOME
-      if (tempCodexHome) {
-        try { fs.rmSync(tempCodexHome, { recursive: true }) } catch { /* ignore */ }
-      }
       if ((code ?? 0) !== 0 && !fullResponse.trim()) {
         const msg = stderrText.trim()
           ? `Codex CLI exited with code ${code ?? 'unknown'}${sig ? ` (${sig})` : ''}: ${stderrText.trim().slice(0, 1200)}`
@@ -285,9 +294,6 @@ export function streamCodexCliChat({ session, message, imagePath, systemPrompt, 
     proc.on('error', (e) => {
       log.error('codex-cli', `Process error: ${e.message}`)
       active.delete(session.id)
-      if (tempCodexHome) {
-        try { fs.rmSync(tempCodexHome, { recursive: true }) } catch { /* ignore */ }
-      }
       write(`data: ${JSON.stringify({ t: 'err', text: e.message })}\n\n`)
       resolve(fullResponse)
     })

--- a/src/lib/providers/codex-cli.ts
+++ b/src/lib/providers/codex-cli.ts
@@ -5,7 +5,7 @@ import { spawn } from 'child_process'
 import type { StreamChatOptions } from './index'
 import { log } from '../server/logger'
 import { loadRuntimeSettings } from '@/lib/server/runtime/runtime-settings'
-import { resolveCliBinary, buildCliEnv, probeCliAuth, attachAbortHandler, symlinkConfigFiles, isStderrNoise } from './cli-utils'
+import { resolveCliBinary, buildCliEnv, probeCliAuth, attachAbortHandler, symlinkConfigFiles, isStderrNoise, ensureCliWorkingDirectory } from './cli-utils'
 import { getAgent } from '@/lib/server/agents/agent-repository'
 import { loadMcpServers } from '@/lib/server/storage'
 
@@ -62,6 +62,7 @@ export function streamCodexCliChat({ session, message, imagePath, systemPrompt, 
 
   // Build clean env — preserves user's CODEX_HOME for auth
   const env = buildCliEnv()
+  const effectiveCwd = ensureCliWorkingDirectory(session.cwd)
 
   // Pass API key if available
   if (session.apiKey) {
@@ -70,7 +71,7 @@ export function streamCodexCliChat({ session, message, imagePath, systemPrompt, 
 
   // Auth probe BEFORE creating temp CODEX_HOME — uses real config dir
   if (!session.apiKey) {
-    const auth = probeCliAuth(binary, 'codex', env, session.cwd)
+    const auth = probeCliAuth(binary, 'codex', env, effectiveCwd)
     if (!auth.authenticated) {
       log.error('codex-cli', auth.errorMessage || 'Auth failed')
       write(`data: ${JSON.stringify({ t: 'err', text: auth.errorMessage || 'Codex CLI is not authenticated.' })}\n\n`)
@@ -149,14 +150,14 @@ export function streamCodexCliChat({ session, message, imagePath, systemPrompt, 
 
   log.info('codex-cli', `Spawning: ${binary}`, {
     args: args.map(a => a.length > 100 ? a.slice(0, 100) + '...' : a),
-    cwd: session.cwd,
+    cwd: effectiveCwd,
     promptLen: prompt.length,
     hasSystemPrompt: !!systemPrompt,
     sessionCodexHome,
   })
 
   const proc = spawn(binary, args, {
-    cwd: session.cwd,
+    cwd: effectiveCwd,
     env,
     stdio: ['pipe', 'pipe', 'pipe'],
     timeout: processTimeoutMs,

--- a/src/lib/server/chat-execution/chat-execution-session-sync.test.ts
+++ b/src/lib/server/chat-execution/chat-execution-session-sync.test.ts
@@ -109,6 +109,97 @@ test('executeSessionChatTurn syncs updated agent runtime fields onto its thread 
   assert.equal(output.connectorContext, null)
 })
 
+test('executeSessionChatTurn persists codex thread id discovered on run-session object', () => {
+  const output = runWithTempDataDir<{
+    codexThreadId: string | null
+  }>(`
+    const storageMod = await import('@/lib/server/storage')
+    const providersMod = await import('@/lib/providers/index')
+    const execMod = await import('@/lib/server/chat-execution/chat-execution')
+    const storage = storageMod.default || storageMod['module.exports'] || storageMod
+    const executeSessionChatTurn = execMod.executeSessionChatTurn
+      || execMod.default?.executeSessionChatTurn
+      || execMod['module.exports']?.executeSessionChatTurn
+    const providers = providersMod.PROVIDERS
+      || providersMod.default?.PROVIDERS
+      || providersMod['module.exports']?.PROVIDERS
+
+    providers['test-codex-sync-provider'] = {
+      id: 'test-codex-sync-provider',
+      name: 'Codex Sync Test Provider',
+      models: ['unit'],
+      requiresApiKey: false,
+      requiresEndpoint: false,
+      handler: {
+        async streamChat(opts) {
+          opts.session.codexThreadId = 'thread_sync_123'
+          return 'ok'
+        },
+      },
+    }
+
+    const now = Date.now()
+    storage.saveAgents({
+      codexsync: {
+        id: 'codexsync',
+        name: 'Codex Sync Agent',
+        description: 'Codex thread id sync test',
+        provider: 'test-codex-sync-provider',
+        model: 'unit',
+        credentialId: null,
+        apiEndpoint: null,
+        fallbackCredentialIds: [],
+        disabled: false,
+        heartbeatEnabled: false,
+        heartbeatIntervalSec: null,
+        extensions: [],
+        createdAt: now,
+        updatedAt: now,
+      },
+    })
+
+    storage.saveSessions({
+      codex_session: {
+        id: 'codex_session',
+        name: 'Codex Session',
+        cwd: process.env.WORKSPACE_DIR,
+        user: 'default',
+        provider: 'test-codex-sync-provider',
+        model: 'unit',
+        claudeSessionId: null,
+        codexThreadId: null,
+        opencodeSessionId: null,
+        geminiSessionId: null,
+        copilotSessionId: null,
+        droidSessionId: null,
+        cursorSessionId: null,
+        qwenSessionId: null,
+        acpSessionId: null,
+        delegateResumeIds: { claudeCode: null, codex: null, opencode: null, gemini: null, copilot: null, droid: null, cursor: null, qwen: null },
+        messages: [],
+        createdAt: now,
+        lastActiveAt: now,
+        sessionType: 'human',
+        agentId: 'codexsync',
+        extensions: [],
+      },
+    })
+
+    await executeSessionChatTurn({
+      sessionId: 'codex_session',
+      message: 'hello',
+      runId: 'run-codex-sync',
+    })
+
+    const persisted = storage.loadSession('codex_session')
+    console.log(JSON.stringify({
+      codexThreadId: persisted?.codexThreadId || null,
+    }))
+  `)
+
+  assert.equal(output.codexThreadId, 'thread_sync_123')
+})
+
 test('executeSessionChatTurn keeps tool-only heartbeats off the visible main-thread history and clears stale connector state', () => {
   const output = runWithTempDataDir<{
     connectorContext: Record<string, unknown> | null

--- a/src/lib/server/chat-execution/chat-turn-finalization.ts
+++ b/src/lib/server/chat-execution/chat-turn-finalization.ts
@@ -436,17 +436,21 @@ export async function finalizeChatTurn(params: {
       }
     }
 
-    persistField('claudeSessionId', session.claudeSessionId)
-    persistField('codexThreadId', session.codexThreadId)
-    persistField('opencodeSessionId', session.opencodeSessionId)
-    persistField('geminiSessionId', session.geminiSessionId)
-    persistField('copilotSessionId', session.copilotSessionId)
-    persistField('droidSessionId', session.droidSessionId)
-    persistField('cursorSessionId', session.cursorSessionId)
-    persistField('qwenSessionId', session.qwenSessionId)
-    persistField('acpSessionId', session.acpSessionId)
+    // Provider handlers receive `sessionForRun` and may mutate CLI resume IDs there.
+    // Persist from run-session first, with fallback to the original session object.
+    persistField('claudeSessionId', sessionForRun.claudeSessionId ?? session.claudeSessionId)
+    persistField('codexThreadId', sessionForRun.codexThreadId ?? session.codexThreadId)
+    persistField('opencodeSessionId', sessionForRun.opencodeSessionId ?? session.opencodeSessionId)
+    persistField('geminiSessionId', sessionForRun.geminiSessionId ?? session.geminiSessionId)
+    persistField('copilotSessionId', sessionForRun.copilotSessionId ?? session.copilotSessionId)
+    persistField('droidSessionId', sessionForRun.droidSessionId ?? session.droidSessionId)
+    persistField('cursorSessionId', sessionForRun.cursorSessionId ?? session.cursorSessionId)
+    persistField('qwenSessionId', sessionForRun.qwenSessionId ?? session.qwenSessionId)
+    persistField('acpSessionId', sessionForRun.acpSessionId ?? session.acpSessionId)
 
-    const sourceResume = session.delegateResumeIds
+    const sourceResume = (sessionForRun.delegateResumeIds && typeof sessionForRun.delegateResumeIds === 'object')
+      ? sessionForRun.delegateResumeIds
+      : session.delegateResumeIds
     if (sourceResume && typeof sourceResume === 'object') {
       const currentResume = (current.delegateResumeIds && typeof current.delegateResumeIds === 'object')
         ? current.delegateResumeIds

--- a/src/stores/slices/session-slice.test.ts
+++ b/src/stores/slices/session-slice.test.ts
@@ -32,11 +32,49 @@ test('selectActiveSessionId prefers override when present', () => {
   assert.equal(selectActiveSessionId(state), 'task-1')
 })
 
-test('selectActiveSessionId falls back to agent thread session', () => {
+test('selectActiveSessionId chooses most recently active session for current agent', () => {
   const state = makeState({
     currentAgentId: 'agent-1',
     agents: { 'agent-1': makeAgent('agent-1', 'thread-1') },
-    sessions: { 'thread-1': makeSession('thread-1') },
+    sessions: {
+      'thread-1': { ...makeSession('thread-1'), agentId: 'agent-1', lastActiveAt: 100 } as unknown as Session,
+      'old-1': { ...makeSession('old-1'), agentId: 'agent-1', lastActiveAt: 90 } as unknown as Session,
+      'latest-1': { ...makeSession('latest-1'), agentId: 'agent-1', lastActiveAt: 200, messageCount: 1 } as unknown as Session,
+      'other-agent': { ...makeSession('other-agent'), agentId: 'agent-2', lastActiveAt: 999 } as unknown as Session,
+    },
+  })
+  assert.equal(selectActiveSessionId(state), 'latest-1')
+})
+
+test('selectActiveSessionId prefers most recent session with content over newer empty thread session', () => {
+  const state = makeState({
+    currentAgentId: 'agent-1',
+    agents: { 'agent-1': makeAgent('agent-1', 'thread-1') },
+    sessions: {
+      'thread-1': { ...makeSession('thread-1'), agentId: 'agent-1', lastActiveAt: 300 } as unknown as Session,
+      'work-1': { ...makeSession('work-1'), agentId: 'agent-1', lastActiveAt: 200, messageCount: 2 } as unknown as Session,
+    },
+  })
+  assert.equal(selectActiveSessionId(state), 'work-1')
+})
+
+test('selectActiveSessionId falls back to thread session when agent has no loaded sessions', () => {
+  const state = makeState({
+    currentAgentId: 'agent-1',
+    agents: { 'agent-1': makeAgent('agent-1', 'thread-1') },
+    sessions: { 'unrelated': { ...makeSession('unrelated'), agentId: 'agent-2' } as unknown as Session },
+  })
+  assert.equal(selectActiveSessionId(state), 'thread-1')
+})
+
+test('selectActiveSessionId falls back to thread session when all loaded sessions are empty', () => {
+  const state = makeState({
+    currentAgentId: 'agent-1',
+    agents: { 'agent-1': makeAgent('agent-1', 'thread-1') },
+    sessions: {
+      'thread-1': { ...makeSession('thread-1'), agentId: 'agent-1', lastActiveAt: 120 } as unknown as Session,
+      'empty-newer': { ...makeSession('empty-newer'), agentId: 'agent-1', lastActiveAt: 220 } as unknown as Session,
+    },
   })
   assert.equal(selectActiveSessionId(state), 'thread-1')
 })

--- a/src/stores/slices/session-slice.ts
+++ b/src/stores/slices/session-slice.ts
@@ -8,6 +8,46 @@ import { createLoader, createInflightDeduplicator } from '../store-utils'
 
 const sessionRefreshDedup = createInflightDeduplicator('sessionSlice_inflightRefreshes')
 
+function getSessionSortScore(session: Session): number {
+  return session.lastAssistantAt
+    || session.lastActiveAt
+    || session.updatedAt
+    || session.createdAt
+    || 0
+}
+
+function hasSessionContent(session: Session): boolean {
+  if (typeof session.messageCount === 'number' && Number.isFinite(session.messageCount) && session.messageCount > 0) {
+    return true
+  }
+  if (session.lastMessageSummary) return true
+  return Array.isArray(session.messages) && session.messages.length > 0
+}
+
+function getLatestAgentSessionId(s: AppState, agentId: string, threadSessionId?: string | null): string | null {
+  let bestAnyId: string | null = null
+  let bestAnyScore = Number.NEGATIVE_INFINITY
+  let bestWithContentId: string | null = null
+  let bestWithContentScore = Number.NEGATIVE_INFINITY
+
+  for (const [sessionId, session] of Object.entries(s.sessions)) {
+    if (session.agentId !== agentId) continue
+    const score = getSessionSortScore(session)
+    if (score > bestAnyScore) {
+      bestAnyScore = score
+      bestAnyId = sessionId
+    }
+    if (hasSessionContent(session) && score > bestWithContentScore) {
+      bestWithContentScore = score
+      bestWithContentId = sessionId
+    }
+  }
+
+  if (bestWithContentId) return bestWithContentId
+  if (threadSessionId && s.sessions[threadSessionId]?.agentId === agentId) return threadSessionId
+  return bestAnyId
+}
+
 /** Derive the active session ID from the current agent — no stored `currentSessionId`. */
 export function selectActiveSessionId(s: AppState): string | null {
   if (s.activeSessionIdOverride && s.sessions[s.activeSessionIdOverride]) {
@@ -15,7 +55,7 @@ export function selectActiveSessionId(s: AppState): string | null {
   }
   if (!s.currentAgentId) return null
   const agent = s.agents[s.currentAgentId]
-  return agent?.threadSessionId ?? null
+  return getLatestAgentSessionId(s, s.currentAgentId, agent?.threadSessionId) || agent?.threadSessionId || null
 }
 
 export interface SessionSlice {


### PR DESCRIPTION
Summary

  - fix Codex CLI continuity so session/thread state is preserved across turns
  - persist provider-mutated resume IDs correctly during turn finalization
  - align CLI behavior with user service setup (SWARMCLAW_HOME, systemd usage, key lookup)
  - improve active session derivation to avoid selecting empty/base sessions over real chat
    sessions
  - add a clear selected-session indicator in inspector session list
  - sort inspector session list by latest session message timestamp

  What changed

  - src/lib/providers/codex-cli.ts
      - persistent per-session Codex home (~/.codex-sessions/<sessionId>)
      - thread-id capture/resume hardening
      - legacy recovery for old/broken session-home cases
  - src/lib/server/chat-execution/chat-turn-finalization.ts
      - persist resume IDs from sessionForRun (provider-mutated object), with fallback
  - src/lib/server/chat-execution/chat-execution-session-sync.test.ts
      - regression test for persisted codexThreadId
  - bin/swarmclaw.js
      - auto-read SWARMCLAW_HOME from user service file when unset
      - prefer systemctl --user for start/run/stop when user service exists
      - richer status path for service/runtime visibility
  - src/cli/index.ts
  - src/cli/index.js
      - access key lookup includes SWARMCLAW_HOME/platform-api-key.txt
  - src/stores/slices/session-slice.ts
      - content-aware active session selection
  - src/stores/slices/session-slice.test.ts
      - tests for content-priority selection + empty-session fallback behavior
  - src/components/agents/inspector-panel.tsx
      - explicit selected-session visual state in session list
      - session ordering by latest message time (with safe fallbacks)
  - src/components/chat/chat-card.tsx
      - selected marker for chat session card

  Behavioral impact

  - SwarmClaw + Codex provider sessions should no longer behave like fresh sessions each message.
  - Agent/session focus should default to the most relevant real chat session.
  - Inspector session list is clearer and ordered by actual conversation recency.

  Validation

  - targeted test passed:
      - npx --yes tsx --test src/stores/slices/session-slice.test.ts
  - production build passed:
      - npm run build
  - user service restarted and verified active:
      - systemctl --user restart swarmclaw.service
      - systemctl --user status swarmclaw.service

  Risk / notes

  - Changes touch session selection and provider/session persistence paths; regressions would
    appear as wrong auto-selected chat or lost resume IDs.
  - Existing untracked local folders (.codex, workspace/) are not included in the commit.

  Suggested labels

  - bug
  - session-management
  - cli
  - ux

  Suggested reviewers

  - owners of chat execution/session persistence
  - owners of CLI/service integration
  - owners of agent inspector/chat UI