### PR TITLE
feat: add dreamProvider/dreamModel settings to route memory consolidation to a custom model

### DIFF
--- a/src/lib/server/memory/dream-service.ts
+++ b/src/lib/server/memory/dream-service.ts
@@ -149,7 +149,19 @@ ${memoryLines.join('\n')}`
 
   try {
     const { buildLLM } = await import('@/lib/server/build-llm')
-    const { llm } = await buildLLM({ agentId })
+    const { loadSettings } = await import('@/lib/server/settings/settings-repository')
+    const settings = loadSettings()
+    // If dreamProvider is set in app settings, route consolidation to it (e.g.
+    // a small local model) instead of the agent's primary generation model.
+    const preferred = settings.dreamProvider
+      ? {
+          provider: settings.dreamProvider,
+          model: settings.dreamModel ?? undefined,
+          credentialId: settings.dreamCredentialId ?? undefined,
+          apiEndpoint: settings.dreamEndpoint ?? undefined,
+        }
+      : undefined
+    const { llm } = await buildLLM({ agentId, preferred })
     const { HumanMessage } = await import('@langchain/core/messages')
 
     const response = await llm.invoke([new HumanMessage(prompt)])

--- a/src/lib/server/memory/memory-consolidation.ts
+++ b/src/lib/server/memory/memory-consolidation.ts
@@ -109,9 +109,20 @@ export async function runDailyConsolidation(): Promise<{
         ...memoryLines,
       ].join('\n')
 
-      // Use the target agent's configured generation provider
+      // If dreamProvider is set in app settings, route consolidation to it;
+      // otherwise fall back to the target agent's configured generation model.
       const { buildLLM } = await import('@/lib/server/build-llm')
-      const { llm } = await buildLLM({ agentId })
+      const { loadSettings } = await import('@/lib/server/settings/settings-repository')
+      const settings = loadSettings()
+      const preferred = settings.dreamProvider
+        ? {
+            provider: settings.dreamProvider,
+            model: settings.dreamModel ?? undefined,
+            credentialId: settings.dreamCredentialId ?? undefined,
+            apiEndpoint: settings.dreamEndpoint ?? undefined,
+          }
+        : undefined
+      const { llm } = await buildLLM({ agentId, preferred })
 
       const response = await llm.invoke([new HumanMessage(prompt)])
       const digestContent = typeof response.content === 'string'

--- a/src/types/app-settings.ts
+++ b/src/types/app-settings.ts
@@ -27,6 +27,14 @@ export interface AppSettings {
   embeddingModel?: string | null
   embeddingCredentialId?: string | null
   embeddingEndpoint?: string | null
+  // Optional model override for memory consolidation / dream cycles. If unset,
+  // consolidation falls back to the target agent's configured generation model.
+  // Useful for routing periodic compaction/summarization to a small local model
+  // (e.g. ollama + gemma) to keep that workload off the agent's primary.
+  dreamProvider?: string | null
+  dreamModel?: string | null
+  dreamCredentialId?: string | null
+  dreamEndpoint?: string | null
   loopMode?: LoopMode
   agentLoopRecursionLimit?: number
   delegationMaxDepth?: number


### PR DESCRIPTION
## Summary

Adds optional app settings (`dreamProvider`, `dreamModel`, `dreamCredentialId`, `dreamEndpoint`) that override the LLM used for memory consolidation and the daily-digest pass. When unset, behavior is unchanged — consolidation falls back to the target agent's configured generation model.

## Motivation

Right now both `dream-service.ts` (Tier-2 consolidation) and `memory-consolidation.ts` (daily digest) call `buildLLM({ agentId })`, so the consolidation work always runs on the agent's primary model. For long-running agents with large memory stores, that primary is usually the expensive option (e.g. `deepseek-v4-pro`). Periodic compaction is a great fit for a small local model — it doesn't need pro-tier reasoning, just consistent summarization — but there's no way to point it elsewhere without changing the agent's main model.

This PR adds an opt-in override. With:

```json
{
  "dreamProvider": "ollama",
  "dreamModel": "gemma4:e4b",
  "dreamEndpoint": "http://localhost:11434"
}
```

…the dream cycle and daily-digest passes run against the local Ollama daemon. The agent's main model is untouched.

## Implementation

- `src/types/app-settings.ts` — adds four optional fields next to the existing `embedding*` ones.
- `src/lib/server/memory/dream-service.ts` (Tier-2 consolidation) — reads settings, builds a `preferred` `GenerationModelPreference`, passes it to `buildLLM`.
- `src/lib/server/memory/memory-consolidation.ts` (daily digest) — same pattern.

`buildLLM` already accepts `preferred` (`GenerationModelPreference | GenerationModelPreference[]`), so the change is purely additive; no other call sites are affected.

## Backward compatibility

- All four new fields are optional.
- The `preferred` argument is only constructed when `settings.dreamProvider` is set; otherwise the call is identical to before (`buildLLM({ agentId })`).
- The `agentId` is still passed alongside `preferred`, so any agent-scoped fallback logic in `buildLLM` (sessions, credentials) still applies.

## Testing notes

Tested locally on 1.9.28:
- With `dreamProvider=ollama` / `dreamModel=gemma4:e4b` / `dreamEndpoint=http://localhost:11434`, manually triggered dream cycles route to the local Ollama daemon — verified by absence of any DeepSeek calls in `app.log` for the duration of the cycle, and by cycle duration consistent with local Gemma throughput (~22 tok/s) rather than cloud latency.
- With the four settings unset, the cycle behaves exactly as on `main` (calls the agent's primary).
- Cooldown / trigger semantics and dream-cycle bookkeeping (`decayed/pruned/promoted/deduped/consolidated/reflections`) are unchanged.

## Diff stats

```
src/lib/server/memory/dream-service.ts        | 14 +++++++++++++-
src/lib/server/memory/memory-consolidation.ts | 15 +++++++++++++--
src/types/app-settings.ts                     |  8 ++++++++
3 files changed, 34 insertions(+), 3 deletions(-)
```

## Known follow-up (separate issue)

Small local models like `gemma4:e4b` often return non-strict JSON to the dream prompt, and `dream-service.ts`'s `text.match(/\{[\s\S]*\}/) + JSON.parse` silently drops unparseable output. Adding `format: 'json'` (Ollama's JSON-constrained generation) on the Ollama provider path would make this much more reliable — I'll file a separate issue with a proposal.