### PR TITLE
fix(email): bypass hostname check when tlsRejectUnauthorized is false (follow-up to #81)

### DIFF
--- a/src/lib/server/connectors/email.ts
+++ b/src/lib/server/connectors/email.ts
@@ -59,8 +59,13 @@ export function parseTlsRejectUnauthorized(value: unknown): boolean {
   return true
 }
 
-export function buildEmailTlsOptions(config: Pick<EmailConfig, 'tlsRejectUnauthorized'>): { rejectUnauthorized: boolean } {
-  return { rejectUnauthorized: config.tlsRejectUnauthorized !== false }
+export function buildEmailTlsOptions(config: Pick<EmailConfig, 'tlsRejectUnauthorized'>): { rejectUnauthorized: boolean; checkServerIdentity?: () => undefined } {
+  const reject = config.tlsRejectUnauthorized !== false
+  // When the user opts out of cert verification, also bypass hostname/altname
+  // matching. Otherwise self-signed-cert servers like Proton Mail Bridge still
+  // fail with "Hostname/IP does not match certificate's altnames" even though
+  // rejectUnauthorized:false is set — defeating the purpose of the option.
+  return reject ? { rejectUnauthorized: true } : { rejectUnauthorized: false, checkServerIdentity: () => undefined }
 }
 
 export function attachImapErrorHandler(imap: ImapErrorEmitter, onDisconnected: () => void): void {


### PR DESCRIPTION
## Summary

Follow-up to #81. With `tlsRejectUnauthorized: false`, the IMAP/SMTP connection still hits Node's hostname verification separately, so connectors to self-signed-cert servers fail with:

```
[email] IMAP socket error: Hostname/IP does not match certificate's altnames:
Host: localhost. is not cert's CN: 127.0.0.1
```

…despite the user explicitly opting out of cert verification. The intent of `tlsRejectUnauthorized: false` is clearly "trust this connection as-is" — bypassing the hostname check is consistent with that intent. This PR adds `checkServerIdentity: () => undefined` to the TLS options when `reject` is false, which is Node's canonical way to skip hostname matching.

## Why this matters

The motivating use case for #81 was being able to point the email connector at a local **Proton Mail Bridge** (which serves IMAP on `127.0.0.1:1143` with a self-signed cert, `CN=127.0.0.1`). Before this fix, the cert *verification* part of #81 works, but the *hostname check* still fires — the connector connects to `127.0.0.1` but Node's checkServerIdentity reports the host as `localhost` (kernel/OS-level reverse resolution), which doesn't match `CN=127.0.0.1` or the cert's `IP Address:127.0.0.1` SAN. End result: `tlsRejectUnauthorized:false` is set, but the connector still can't reach Bridge.

## Change

```diff
-export function buildEmailTlsOptions(config: Pick<EmailConfig, 'tlsRejectUnauthorized'>): { rejectUnauthorized: boolean } {
-  return { rejectUnauthorized: config.tlsRejectUnauthorized !== false }
+export function buildEmailTlsOptions(config: Pick<EmailConfig, 'tlsRejectUnauthorized'>): { rejectUnauthorized: boolean; checkServerIdentity?: () => undefined } {
+  const reject = config.tlsRejectUnauthorized !== false
+  return reject ? { rejectUnauthorized: true } : { rejectUnauthorized: false, checkServerIdentity: () => undefined }
 }
```

## Backward compatibility

- Default behavior (when `tlsRejectUnauthorized` is unset or `true`) is unchanged: strict TLS, normal hostname check.
- Only when the user explicitly opts out (`tlsRejectUnauthorized: false`) does `checkServerIdentity` get replaced.

## Testing

Verified locally against Proton Mail Bridge:

```
[email] IMAP connected to 127.0.0.1
[email] Initial highwater UID: ... in INBOX
[email] Connector started — polling every 60s
```

No errors. Same flow with `tlsRejectUnauthorized: true` (or unset) correctly fails verification — verified strict mode still works.