### PR TITLE
fix(cli): prefer bundled index.js for legacy TS CLI (follow-up to #82)

### DIFF
--- a/bin/swarmclaw.js
+++ b/bin/swarmclaw.js
@@ -80,7 +80,13 @@ function buildLegacyTsCliArgs(cliPath, argv, options = {}) {
 }
 
 function resolveLegacyTsCliPath() {
-  return path.join(__dirname, '..', 'src', 'cli', 'index.ts')
+  // Prefer the bundled compiled .js. The shipped .ts entrypoint requires either
+  // Node's type-stripping (disabled under node_modules) or a tsx runtime
+  // resolvable from the *spawned* process's CWD — both fragile when the CLI is
+  // invoked from a project directory that doesn't itself depend on tsx. The
+  // compiled .js is shipped right next to the .ts and is bytewise identical
+  // functionality (runMappedCli already imports it).
+  return path.join(__dirname, '..', 'src', 'cli', 'index.js')
 }
 
 function normalizeLegacyTsCliArgv(argv) {


### PR DESCRIPTION
## Summary

Follow-up to #82. With the type-stripping path correctly disabled under `node_modules`, `buildLegacyTsCliArgs` falls through to the `tsx` path:

```js
return ['--no-warnings', '--import', 'tsx', cliPath, ...argv]
```

`--import tsx` makes Node resolve `tsx` from the **spawned process's CWD**, not from the swarmclaw package location. So if a user runs `swarmclaw agents list` from a project directory that doesn't itself have `tsx` installed (the common case for installed-package use), Node throws:

```
node:internal/modules/package_json_reader:301
  throw new ERR_MODULE_NOT_FOUND(packageName, fileURLToPath(base), null);
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'tsx' imported from /Users/sigli/Desktop/Projects/compass-ops/
```

Installing `tsx` globally doesn't help either, because Node's package resolution from a CWD doesn't pick up globally-installed packages.

## Fix

Point `resolveLegacyTsCliPath()` at the bundled compiled `.js`. The launcher already has a fast path for `.js`/`.cjs`/`.mjs` extensions (just runs node on the file directly — no `--experimental-strip-types`, no `--import tsx`), and `src/cli/index.js` is already shipped (it's what `runMappedCli` imports). So this avoids the type-stripping path entirely on installed packages and also dodges the tsx-resolution issue.

```diff
 function resolveLegacyTsCliPath() {
-  return path.join(__dirname, '..', 'src', 'cli', 'index.ts')
+  return path.join(__dirname, '..', 'src', 'cli', 'index.js')
 }
```

## Backward compatibility

- The `.js` and `.ts` files are produced from the same source — functionally identical.
- The `buildLegacyTsCliArgs` short-circuit for `.js`/`.cjs`/`.mjs` already exists, so the rest of the launcher logic is unchanged.
- `runMappedCli` already uses `index.js`, so this just brings `runLegacyTsCli` in line.

## Testing

Reproduces consistently on Node 25 (macOS, arm64) by running any legacy group command from a CWD without local `tsx`:

```
$ cd /tmp && swarmclaw agents list
ERR_MODULE_NOT_FOUND: Cannot find package 'tsx' ...
```

With this patch:

```
$ cd /tmp && swarmclaw agents list
[returns the agent list as expected]
```

Tested with both `swarmclaw agents list` and `swarmclaw autonomy estop`. Top-level commands (`start`, `stop`, `status`, `doctor`, `--help`) — which go through `runMappedCli` — are unaffected (already used `.js`).