### PR TITLE
feat: per-agent dream-model override via dreamConfig

### DIFF
--- a/src/lib/server/memory/dream-generation-preference.ts
+++ b/src/lib/server/memory/dream-generation-preference.ts
@@ -1,14 +1,42 @@
 import type { GenerationModelPreference } from '@/lib/server/build-llm'
-import type { AppSettings } from '@/types'
+import type { AppSettings, DreamConfig } from '@/types'
 
 type DreamGenerationSettings = Pick<AppSettings, 'dreamProvider' | 'dreamModel' | 'dreamCredentialId' | 'dreamEndpoint'> | Record<string, unknown> | null | undefined
+
+type DreamConfigOverride = Pick<DreamConfig, 'provider' | 'model' | 'credentialId' | 'endpoint'> | Partial<DreamConfig> | Record<string, unknown> | null | undefined
 
 function optionalSettingString(value: unknown): string | undefined {
   const normalized = typeof value === 'string' ? value.trim() : ''
   return normalized || undefined
 }
 
-export function resolveDreamGenerationPreference(settings: DreamGenerationSettings): GenerationModelPreference | undefined {
+/**
+ * Resolve which model to use for memory consolidation / dream cycles.
+ *
+ * Precedence:
+ *   1. Per-agent override (`dreamConfig.provider` on the Agent record)
+ *   2. Global app settings (`dreamProvider` etc.)
+ *   3. undefined — caller falls back to the agent's primary generation model
+ *
+ * The per-agent override lets you route different agents to different dream
+ * models (e.g. cheap local for most, but a stronger model for an agent whose
+ * memory mix needs more capable structured-output generation).
+ */
+export function resolveDreamGenerationPreference(
+  settings: DreamGenerationSettings,
+  override?: DreamConfigOverride,
+): GenerationModelPreference | undefined {
+  const overrideRecord = (override || {}) as Record<string, unknown>
+  const overrideProvider = optionalSettingString(overrideRecord.provider)
+  if (overrideProvider) {
+    return {
+      provider: overrideProvider,
+      model: optionalSettingString(overrideRecord.model),
+      credentialId: optionalSettingString(overrideRecord.credentialId),
+      apiEndpoint: optionalSettingString(overrideRecord.endpoint),
+    }
+  }
+
   const record = (settings || {}) as Record<string, unknown>
   const provider = optionalSettingString(record.dreamProvider)
   if (!provider) return undefined

--- a/src/lib/server/memory/dream-service.ts
+++ b/src/lib/server/memory/dream-service.ts
@@ -216,7 +216,9 @@ ${memoryLines.join('\n')}`
   try {
     const { buildLLM } = await import('@/lib/server/build-llm')
     const { loadSettings } = await import('@/lib/server/settings/settings-repository')
-    const preferred = resolveDreamGenerationPreference(loadSettings())
+    // `config` is the resolved per-agent dream config (defaults + overrides);
+    // pass it so a per-agent provider/model takes precedence over global settings.
+    const preferred = resolveDreamGenerationPreference(loadSettings(), config)
     const { llm } = await buildLLM({ agentId, preferred, responseFormat: 'json_object' })
     const { HumanMessage } = await import('@langchain/core/messages')
 

--- a/src/lib/server/memory/memory-consolidation.ts
+++ b/src/lib/server/memory/memory-consolidation.ts
@@ -48,7 +48,7 @@ export function canCreateDailyDigestForAgent(
   try {
     resolveGenerationModelConfig({
       agentId,
-      preferred: resolveDreamGenerationPreference(settings),
+      preferred: resolveDreamGenerationPreference(settings, agent.dreamConfig),
     })
     return true
   } catch (err: unknown) {
@@ -118,10 +118,11 @@ export async function runDailyConsolidation(): Promise<{
       ].join('\n')
 
       // Use an optional dream-model override before the target agent's generation provider.
+      // Precedence: per-agent dreamConfig override → global dream* settings → agent's primary.
       const { buildLLM } = await import('@/lib/server/build-llm')
       const { llm } = await buildLLM({
         agentId,
-        preferred: resolveDreamGenerationPreference(settings),
+        preferred: resolveDreamGenerationPreference(settings, agents[agentId]?.dreamConfig),
       })
 
       const response = await llm.invoke([new HumanMessage(prompt)])

--- a/src/types/dream.ts
+++ b/src/types/dream.ts
@@ -33,6 +33,14 @@ export interface DreamConfig {
   pruneThresholdDays: number
   tier2Enabled: boolean
   tier2MaxMemories: number
+  // Optional per-agent override for the consolidation/dream LLM. When set,
+  // takes precedence over the global `dream*` app settings. When unset, the
+  // helper falls back to global settings, then to the agent's primary
+  // generation model — same precedence as before.
+  provider?: string | null
+  model?: string | null
+  credentialId?: string | null
+  endpoint?: string | null
 }
 
 export const DEFAULT_DREAM_CONFIG: DreamConfig = {


### PR DESCRIPTION
## Summary

Extends the dream-model override (introduced in v1.9.30, building on my PR #84) to support a *per-agent* setting that takes precedence over the global app settings. Adds four optional fields to `DreamConfig` — `provider`, `model`, `credentialId`, `endpoint` — and reuses the existing `PATCH /api/agents/:id/dream` endpoint to set them.

## Why

The global `dreamProvider` / `dreamModel` settings work great when one model fits all agents. They don't when one agent's memory mix is harder for the global choice to handle.

Concrete data from local testing (v1.9.31, `dreamProvider=ollama` + `dreamModel=gemma4:e4b`):

| Agent | Memories | Tier-2 result |
|---|---|---|
| Marian | 692 | ✅ 4 consolidations + 3 reflections |
| Atlas | 893 | ✅ 3 consolidations + 3 reflections |
| Hakim (orchestrator) | 1497 | ❌ `"Tier 2 dream response was not valid structured JSON."` |

Same model, same prompt, same `format:'json'` plumbing — Marian and Atlas (editorial / strategy domains) produce clean structured output. Hakim's memories are denser and more technical (orchestration internals, tool-call traces, failure-mode reflections); the small local model wobbles on producing the exact schema for that mix.

Today the only mitigation is changing the *global* `dreamProvider` to something stronger — which then runs every agent through it, defeating the cost-savings of the local model for the other 90% of cases. A per-agent override fixes this surgically.

## Precedence

In ` resolveDreamGenerationPreference`:

1. **Per-agent dreamConfig override** (` agent.dreamConfig.provider`)
2. **Global app settings** (` settings.dreamProvider`)
3. **undefined** — caller falls back to the agent's primary generation model

When the per-agent fields are unset (the default), behavior is byte-identical to current ` main`.

## API

No new endpoints. Reuses the existing dream-config patch route:

` ` `
PATCH /api/agents/<id>/dream
{
  "dreamConfig": {
    "provider": "ollama",
    "model": "gemma4:26b"
  }
}
` ` `

Or, for an agent that needs a stronger model on a hosted provider:

` ` `
PATCH /api/agents/<id>/dream
{
  "dreamConfig": {
    "provider": "deepseek",
    "model": "deepseek-v4-flash",
    "credentialId": "cred_..."
  }
}
` ` `

## Files

- ` src/types/dream.ts` — adds ` provider`/` model`/` credentialId`/` endpoint` to ` DreamConfig` (all optional).
- ` src/lib/server/memory/dream-generation-preference.ts` — accepts a second ` override` argument; checks it first, then falls back to the existing settings-based path.
- ` src/lib/server/memory/dream-service.ts` — passes ` config` (the resolved per-agent dream config that ` runTier2Dream` already receives) to the helper.
- ` src/lib/server/memory/memory-consolidation.ts` — ` canCreateDailyDigestForAgent` and ` runDailyConsolidation` pass ` agents[agentId]?.dreamConfig` to the helper.

## Backward compatibility

- New fields are optional in ` DreamConfig`. Existing dream configs are untouched.
- ` resolveDreamGenerationPreference`'s old signature still works (the override arg is optional, defaults to ` undefined`).
- Type extensions don't require a migration — ` dreamConfig` is already a free-form blob on the agent record.

## Testing status

The bug context — Hakim's Tier-2 cycle failing JSON parse on Gemma 4 e4b while Marian's and Atlas's succeed — is reproduced repeatedly on v1.9.31 in my setup (numbers in the table above are from this morning's cycles).

**The patch itself is reviewed by inspection, not yet runtime-tested locally** — I kept the install zero-patched so the PR diff stands on its own without local state. The change surface is small (one extra optional arg through one helper; one new arg passed at each of two call sites; four optional fields on a type already extended in a recent release), and the precedence ordering is structurally identical to what already works at the global-settings layer.

If you'd like a runtime verification before merging, let me know and I'll patch the local install, run a manual cycle on Hakim with ` dreamConfig.provider="deepseek"` set, and post the result.