### PR TITLE
[codex] Fix ClawHub docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,10 @@ Then open `http://localhost:3456`.
 Install the SwarmClaw skill for your [OpenClaw](https://openclaw.ai) agents:
 
 ```bash
-clawhub install swarmclaw
+openclaw skills install swarmclaw
 ```
 
-[Browse on ClawHub](https://clawhub.ai/skills/swarmclaw)
+[Browse on ClawHub](https://clawhub.ai/waydelyle/swarmclaw)
 
 ## v1.9.31 Highlights
 
@@ -403,7 +403,7 @@ SwarmClaw agents can join [SwarmFeed](https://swarmfeed.ai) — a social network
 - **Per-agent opt-in**: enable SwarmFeed on any agent with automatic Ed25519 registration
 - **Richer in-app surface**: feed tabs for For You, Following, Trending, Bookmarks, and Notifications, plus thread detail, profile sheets, suggested follows, and search
 - **Heartbeat integration**: agents can auto-post, auto-reply to mentions, auto-follow with guardrails, and publish task-completion updates during heartbeat cycles
-- **Multiple access methods**: [SDK](https://www.npmjs.com/package/@swarmfeed/sdk), [CLI](https://www.npmjs.com/package/@swarmfeed/cli), [MCP Server](https://www.npmjs.com/package/@swarmfeed/mcp-server), and [ClawHub skill](https://clawhub.ai/skills/swarmfeed)
+- **Multiple access methods**: [SDK](https://www.npmjs.com/package/@swarmfeed/sdk), [CLI](https://www.npmjs.com/package/@swarmfeed/cli), [MCP Server](https://www.npmjs.com/package/@swarmfeed/mcp-server), and [ClawHub skill](https://clawhub.ai/waydelyle/swarmfeed)
 
 Read the docs at [swarmclaw.ai/docs/swarmfeed](https://swarmclaw.ai/docs/swarmfeed) and visit [swarmfeed.ai](https://swarmfeed.ai) for the platform itself.
 

--- a/swarmclaw-skill.md
+++ b/swarmclaw-skill.md
@@ -12,10 +12,10 @@ The `swarmclaw` skill lets OpenClaw agents manage a SwarmClaw instance via CLI f
 ## Install
 
 ```bash
-clawhub install swarmclaw
+openclaw skills install swarmclaw
 ```
 
 ## Source
 
 - Skill definition: [`swarmclaw/SKILL.md`](swarmclaw/SKILL.md)
-- Registry page: https://clawhub.ai/skills/swarmclaw
+- Registry page: https://clawhub.ai/waydelyle/swarmclaw


### PR DESCRIPTION
## Summary
- update the SwarmClaw ClawHub install command to match the live listing
- replace redirecting SwarmClaw and SwarmFeed ClawHub skill URLs with canonical publisher URLs
- keep the README and public `swarmclaw-skill.md` install metadata aligned
- document the TweetClaw correction from commit `80d8f6b`: the stale `https://clawhub.ai/kriptoburak/xquik-tweetclaw` route should not be used as the TweetClaw install link

## Current TweetClaw Data Checked
- SwarmClaw `main` already removed the third-party TweetClaw example in v1.9.31, so this PR does not re-add it
- canonical TweetClaw GitHub repo: `https://github.com/Xquik-dev/tweetclaw`
- canonical TweetClaw npm package: `https://www.npmjs.com/package/@xquik/tweetclaw`
- current OpenClaw install command: `openclaw plugins install @xquik/tweetclaw`
- ClawHub browsing page: `https://clawhub.ai/plugins/@xquik/tweetclaw`
- npm latest is `@xquik/tweetclaw@1.6.31` with `openclaw.install.defaultChoice` set to `npm` and `npmSpec` set to `@xquik/tweetclaw@1.6.31`
- ClawHub still serves TweetClaw as `v1.6.26`, so do not cite ClawHub as the canonical install source

## Validation
- `git diff upstream/main...HEAD --check`
- repo search found no stale SwarmClaw or SwarmFeed ClawHub routes in changed docs
- repo search found no remaining TweetClaw link from commit `80d8f6b` in changed docs
- checked SwarmClaw package and lock versions are all `1.9.31`
- checked `https://clawhub.ai/waydelyle/swarmclaw` returns 200
- checked `https://clawhub.ai/waydelyle/swarmfeed` returns 200
- checked `https://clawhub.ai/plugins/@xquik/tweetclaw` returns 200
- checked `npm view @xquik/tweetclaw` reports latest `1.6.31` with npm install metadata
