### PR TITLE
feat: auto-compaction model override via compactionProvider/Model settings

### DIFF
--- a/src/lib/server/chat-execution/compaction-generation-preference.ts
+++ b/src/lib/server/chat-execution/compaction-generation-preference.ts
@@ -1,0 +1,25 @@
+import type { GenerationModelPreference } from '@/lib/server/build-llm'
+import type { AppSettings } from '@/types'
+
+type CompactionGenerationSettings = Pick<AppSettings, 'compactionProvider' | 'compactionModel' | 'compactionCredentialId' | 'compactionEndpoint'> | Record<string, unknown> | null | undefined
+
+function optionalSettingString(value: unknown): string | undefined {
+  const normalized = typeof value === 'string' ? value.trim() : ''
+  return normalized || undefined
+}
+
+/** Mirrors resolveDreamGenerationPreference — returns a model preference for
+ *  the auto-compaction summarizer if app settings opt into a routing override,
+ *  otherwise undefined (caller falls back to the session's primary model). */
+export function resolveCompactionGenerationPreference(settings: CompactionGenerationSettings): GenerationModelPreference | undefined {
+  const record = (settings || {}) as Record<string, unknown>
+  const provider = optionalSettingString(record.compactionProvider)
+  if (!provider) return undefined
+
+  return {
+    provider,
+    model: optionalSettingString(record.compactionModel),
+    credentialId: optionalSettingString(record.compactionCredentialId),
+    apiEndpoint: optionalSettingString(record.compactionEndpoint),
+  }
+}

--- a/src/lib/server/chat-execution/stream-agent-chat.ts
+++ b/src/lib/server/chat-execution/stream-agent-chat.ts
@@ -682,8 +682,29 @@ async function streamAgentChatCore(opts: StreamAgentChatOpts): Promise<StreamAge
       reserveTokens,
       includeToolEvents: false,
     })) {
+      // Resolve compaction model: if app settings opt into an override, build
+      // a separate LLM for the summarizer (cheap/local model); otherwise reuse
+      // the session's primary llm. Mirrors the dream-model override path.
+      const { resolveCompactionGenerationPreference } = await import('@/lib/server/chat-execution/compaction-generation-preference')
+      const { buildLLM } = await import('@/lib/server/build-llm')
+      // loadSettings is imported at the top of this file.
+      const settings = loadSettings()
+      const compactionPref = resolveCompactionGenerationPreference(settings)
+      let summarizerLlm = llm
+      let summarizerProvider = session.provider
+      let summarizerModel = session.model
+      if (compactionPref) {
+        try {
+          const built = await buildLLM({ preferred: compactionPref, sessionId: session.id, agentId: session.agentId || null })
+          summarizerLlm = built.llm
+          summarizerProvider = built.provider
+          summarizerModel = built.model
+        } catch (overrideErr) {
+          log.warn(TAG, `Compaction override LLM build failed for ${session.id}; falling back to session model:`, overrideErr)
+        }
+      }
       const summarize = async (prompt: string): Promise<string> => {
-        const response = await llm.invoke([new HumanMessage(prompt)])
+        const response = await summarizerLlm.invoke([new HumanMessage(prompt)])
         if (typeof response.content === 'string') return response.content
         if (Array.isArray(response.content)) {
           return response.content
@@ -694,8 +715,8 @@ async function streamAgentChatCore(opts: StreamAgentChatOpts): Promise<StreamAge
       }
       const result = await llmCompact({
         messages: recentHistory,
-        provider: session.provider,
-        model: session.model,
+        provider: summarizerProvider,
+        model: summarizerModel,
         agentId: session.agentId || null,
         sessionId: session.id,
         summarize,
@@ -704,6 +725,7 @@ async function streamAgentChatCore(opts: StreamAgentChatOpts): Promise<StreamAge
       log.info(TAG,
         `Auto-compacted ${session.id}: ${recentHistory.length} → ${effectiveHistory.length} msgs` +
         ` (prompt history ${promptHistoryTokens} tokens)` +
+        (compactionPref ? ` (override ${summarizerProvider}/${summarizerModel})` : '') +
         (result.summaryAdded ? ' (LLM summary)' : ' (sliding window fallback)'),
       )
     }

--- a/src/types/app-settings.ts
+++ b/src/types/app-settings.ts
@@ -32,6 +32,14 @@ export interface AppSettings {
   dreamModel?: string | null
   dreamCredentialId?: string | null
   dreamEndpoint?: string | null
+  // Optional model override for auto-compaction (live-loop conversation
+  // summarization triggered when context usage hits the auto-compact
+  // threshold). Lets the user route the summarizer to a cheaper or faster
+  // model than the agent's primary generation model.
+  compactionProvider?: string | null
+  compactionModel?: string | null
+  compactionCredentialId?: string | null
+  compactionEndpoint?: string | null
   loopMode?: LoopMode
   agentLoopRecursionLimit?: number
   delegationMaxDepth?: number


### PR DESCRIPTION
## Summary

Adds four optional `AppSettings` fields — `compactionProvider`, `compactionModel`, `compactionCredentialId`, `compactionEndpoint` — that let the operator route the auto-compaction summarizer (live-loop conversation summarization triggered at the 80% context threshold in `stream-agent-chat.ts`) to a cheaper or faster model than the agent's primary generation model.

Mirrors the dream-model routing introduced in v1.9.30 (`dreamProvider` / `dreamModel` / etc.).

## Motivation

Today the `summarize()` closure in the auto-compaction branch of `stream-agent-chat.ts` uses the session's own `llm` — i.e. the agent's primary generation model. For an agent running on a premium tier (e.g. `deepseek-v4-pro`), every compaction burns the expensive model just to compress chat history. Compaction is exactly the kind of "smaller, faster, cheaper" job a `deepseek-v4-flash` / local Ollama Gemma / similar should handle, with no behavior change to the agent's primary generation.

In our setup we have several agents on `deepseek-v4-pro`. Sessions that loop a lot trigger compaction frequently — routing the summarizer to flash or local Gemma cuts the compaction spend meaningfully without changing what the agent ships.

## Resolution

In `stream-agent-chat.ts` auto-compaction branch:

1. If `compactionProvider` is set, build a separate LLM via `buildLLM({ preferred: compactionPref })` and use it for the `summarize()` closure.
2. If unset, behavior is unchanged — `summarize` uses `session.llm`.
3. If the override build fails, log a warning and fall back to the session llm rather than blocking the compaction.

The override (provider/model) is logged in the auto-compaction info line so operators can verify it's in effect.

## Files

- `src/types/app-settings.ts` — 4 new optional fields
- `src/lib/server/chat-execution/compaction-generation-preference.ts` — new helper, exact mirror of `dream-generation-preference.ts`
- `src/lib/server/chat-execution/stream-agent-chat.ts` — build override llm in the auto-compact branch

## Test plan

- [x] Reviewed by inspection (no runtime test added; no test exists for the parallel dream-generation-preference either).
- [ ] Operator verification: set `compactionProvider=ollama, compactionModel=gemma4:e4b, compactionEndpoint=http://localhost:11434` on the server, run a chat to compaction threshold, check the log line for `(override ollama/gemma4:e4b)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)