### PR TITLE
feat: reflection-write quality gate via reflectionMinQuality setting

### DIFF
--- a/src/lib/server/autonomy/supervisor-reflection.ts
+++ b/src/lib/server/autonomy/supervisor-reflection.ts
@@ -1085,7 +1085,21 @@ export async function observeAutonomyRunOutcome(
   if (parsed.skip) return { incidents, reflection: null }
 
   const reflectionId = genId()
-  const autoMemoryIds = settings.reflectionAutoWriteMemory
+  // Quality gate: if reflectionMinQuality is set above 0, only write memories
+  // when the reflection's qualityScore meets or exceeds it. Null/undefined
+  // qualityScore is admitted (we don't want a model that omits the score to
+  // silently lose all memory writes).
+  const minQuality = typeof settings.reflectionMinQuality === 'number' ? settings.reflectionMinQuality : 0
+  const qualityScore = parsed.qualityScore
+  const qualityGateOpen = minQuality <= 0
+    || qualityScore == null
+    || qualityScore >= minQuality
+  if (!qualityGateOpen) {
+    log.info(TAG,
+      `Reflection ${reflectionId} below quality gate (score=${qualityScore?.toFixed(2) ?? 'null'}, threshold=${minQuality.toFixed(2)}); skipping memory writes`,
+    )
+  }
+  const autoMemoryIds = settings.reflectionAutoWriteMemory && qualityGateOpen
     ? writeReflectionMemories({
         reflectionId,
         runId: input.runId,

--- a/src/types/app-settings.ts
+++ b/src/types/app-settings.ts
@@ -103,6 +103,15 @@ export interface AppSettings {
   autonomyResumeApprovalsEnabled?: boolean
   reflectionEnabled?: boolean
   reflectionAutoWriteMemory?: boolean
+  /** Minimum reflection quality score (0-1, as emitted by the reflection
+   *  classifier in `parsed.qualityScore`) required to auto-write memories.
+   *  Defaults to 0 (no gating, behavior unchanged). When raised, low-quality
+   *  reflections still produce a RunReflection record but skip the per-kind
+   *  memory writes — reducing the bloat where 95%+ of memory rows are
+   *  routine reflection/* entries that never get retrieved.
+   *  Reflections with a null qualityScore are admitted regardless (so an
+   *  upstream parse failure can't silently lose all memory writes). */
+  reflectionMinQuality?: number
   memoryReferenceDepth?: number
   maxMemoriesPerLookup?: number
   maxLinkedMemoriesExpanded?: number


### PR DESCRIPTION
## Summary

Adds an optional `AppSettings.reflectionMinQuality` (0-1) that gates the per-kind memory writes performed by `writeReflectionMemories()` in `supervisor-reflection.ts`. Default is `0` (no gating, behavior unchanged); when raised, reflections whose classifier-emitted `qualityScore` falls below the threshold still produce a `RunReflection` record but skip the per-kind memory writes.

## Motivation

Looking at the memory tables in production agents, ~95% of all rows are routine `reflection/*` entries (invariant, lesson, derived, failure, communication, relationship, significant_event, profile, boundary, open_loop). Every reflection emits up to 10 memories — one per kind. SwarmClaw already does cross-kind text-dedup within a run and cross-run dedup over a 7-day window, but the gate is text-equality only; semantically similar reflections still accumulate. Many of these never get retrieved.

The classifier already produces a `qualityScore` per reflection. A simple operator knob to raise the write bar prunes the long tail without needing to disable reflections entirely.

## Resolution

In `executeSupervisorAutoActions` (the per-run reflection writer):

- `qualityScore >= reflectionMinQuality` → write as before.
- `qualityScore < reflectionMinQuality` → skip writes, log the gate decision so operators can audit which reflections are dropping out.
- `qualityScore == null` → admit regardless. We don't want a model that omits the score field (or a parse oddity) to silently lose all memory writes.

The `RunReflection` record itself is still written so the autonomy/reflections endpoint still reports the reflection occurred; only the per-kind memory rows are suppressed.

## Files

- `src/types/app-settings.ts` — `reflectionMinQuality?: number` field
- `src/lib/server/autonomy/supervisor-reflection.ts` — gate `writeReflectionMemories()` on the quality threshold

## Test plan

- [x] Reviewed by inspection.
- [ ] Operator verification: set `reflectionMinQuality=0.5`, run reflection-producing sessions, confirm the gate-skip log line appears for low-quality reflections and that `RunReflection` records still exist but `autoMemoryIds` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)