### PR TITLE
feat: optional embedding-based dedup on reflection memory writes

### DIFF
--- a/src/lib/server/autonomy/supervisor-reflection.ts
+++ b/src/lib/server/autonomy/supervisor-reflection.ts
@@ -744,7 +744,7 @@ function inferFollowUpAt(note: string, createdAt: number): number {
   return createdAt + 7 * 24 * 3600_000
 }
 
-function writeReflectionMemories(params: {
+async function writeReflectionMemories(params: {
   reflectionId: string
   runId: string
   sessionId: string
@@ -761,7 +761,7 @@ function writeReflectionMemories(params: {
   profile: string[]
   boundaries: string[]
   openLoops: string[]
-}): string[] {
+}): Promise<string[]> {
   const memoryDb = getMemoryDb()
   const memoryIds: string[] = []
   const incidentIds = params.incidents.map((incident) => incident.id)
@@ -809,11 +809,53 @@ function writeReflectionMemories(params: {
     // dedup only rather than blocking the reflection write.
   }
 
+  // Semantic dedup (opt-in): on top of the text-equality cross-run dedup
+  // above, compare each candidate note's embedding against recent reflection
+  // memories' embeddings. Catches near-duplicates the LLM re-derives in
+  // different words ("Always verify before acting" / "Confirm state first").
+  // Falls back gracefully when embeddings aren't configured.
+  let appSettings: AppSettings | null = null
+  try { appSettings = loadSettings() } catch { appSettings = null }
+  const semanticDedupEnabled = Boolean(appSettings?.reflectionSemanticDedupEnabled)
+  const semanticDedupThreshold = typeof appSettings?.reflectionSemanticDedupThreshold === 'number'
+    ? appSettings.reflectionSemanticDedupThreshold
+    : 0.88
+  const semanticSkip = new Set<string>()
+  if (semanticDedupEnabled && params.agentId) {
+    try {
+      const recentEmb = memoryDb.recentReflectionEmbeddings(params.agentId, crossRunDedupCutoff, 500)
+        .filter((r) => Array.isArray(r.embedding) && r.embedding.length > 0) as Array<{ id: string; content: string; embedding: number[] }>
+      if (recentEmb.length > 0) {
+        const { getEmbedding, cosineSimilarity } = await import('@/lib/server/embeddings')
+        for (const group of groups) {
+          for (const note of group.notes) {
+            const trimmed = (note || '').trim()
+            if (!trimmed) continue
+            const norm = normalizeNote(trimmed)
+            if (!norm || seenNormalized.has(norm) || semanticSkip.has(norm)) continue
+            const emb = await getEmbedding(trimmed)
+            if (!emb) continue
+            for (const r of recentEmb) {
+              if (cosineSimilarity(emb, r.embedding) >= semanticDedupThreshold) {
+                semanticSkip.add(norm)
+                break
+              }
+            }
+          }
+        }
+      }
+    } catch {
+      // Best-effort: any failure (embedder offline, DB blip) falls through to
+      // the existing text-equality dedup. Never block the write.
+    }
+  }
+
   for (const group of groups) {
     for (const note of group.notes) {
       const norm = normalizeNote(note)
       if (!norm) continue
       if (seenNormalized.has(norm)) continue
+      if (semanticSkip.has(norm)) continue
       seenNormalized.add(norm)
       const metadata: Record<string, unknown> = {
         origin: 'autonomy-reflection',
@@ -1086,7 +1128,7 @@ export async function observeAutonomyRunOutcome(
 
   const reflectionId = genId()
   const autoMemoryIds = settings.reflectionAutoWriteMemory
-    ? writeReflectionMemories({
+    ? await writeReflectionMemories({
         reflectionId,
         runId: input.runId,
         sessionId: input.sessionId,

--- a/src/lib/server/memory/memory-db.ts
+++ b/src/lib/server/memory/memory-db.ts
@@ -1270,6 +1270,30 @@ function initDb() {
       return (stmts.listByAgent.all(agentId, safeLimit) as any[]).map(rowToEntry)
     },
 
+    /** Return recent reflection/* memories with their embeddings deserialized
+     *  for semantic dedup. Memories without an embedding (older rows, or
+     *  embedding still being computed in background) are included with a
+     *  null embedding so callers can fall back to text dedup. */
+    recentReflectionEmbeddings(
+      agentId: string,
+      sinceMs: number,
+      limit = 200,
+    ): Array<{ id: string; content: string; embedding: number[] | null }> {
+      const safeLimit = Math.max(1, Math.min(500, Math.trunc(limit)))
+      const rows = db.prepare(
+        `SELECT id, content, embedding FROM memories
+         WHERE (agentId = ? OR sharedWith LIKE ?)
+           AND category LIKE 'reflection/%'
+           AND updatedAt >= ?
+         ORDER BY updatedAt DESC LIMIT ?`,
+      ).all(agentId, `%"${agentId}"%`, sinceMs, safeLimit) as Array<{ id: string; content: string; embedding: Buffer | null }>
+      return rows.map((row) => ({
+        id: row.id,
+        content: row.content || '',
+        embedding: row.embedding ? deserializeEmbedding(row.embedding) : null,
+      }))
+    },
+
     getFrequentlyAccessedByAgent(agentId: string, minAccessCount = 3, sinceDays = 7): MemoryEntry[] {
       const cutoff = Date.now() - sinceDays * 86_400_000
       const rows = stmts.frequentlyAccessedByAgent.all(agentId, minAccessCount, cutoff) as Record<string, unknown>[]

--- a/src/types/app-settings.ts
+++ b/src/types/app-settings.ts
@@ -103,6 +103,17 @@ export interface AppSettings {
   autonomyResumeApprovalsEnabled?: boolean
   reflectionEnabled?: boolean
   reflectionAutoWriteMemory?: boolean
+  /** Enable embedding-based dedup on reflection memory writes — when set,
+   *  each new reflection note is embedded and compared against recent
+   *  reflection memories in the cross-run window; notes with cosine
+   *  similarity above the threshold are skipped. Complements the existing
+   *  text-equality cross-run dedup. Default false (opt-in).
+   *  Requires an embedding provider to be configured (embeddingProvider). */
+  reflectionSemanticDedupEnabled?: boolean
+  /** Cosine threshold above which a candidate reflection is considered
+   *  semantically duplicate. Range 0-1; 0.85-0.92 is a sane band for
+   *  near-duplicate detection on nomic-embed-text. Default 0.88. */
+  reflectionSemanticDedupThreshold?: number
   memoryReferenceDepth?: number
   maxMemoriesPerLookup?: number
   maxLinkedMemoriesExpanded?: number


### PR DESCRIPTION
## Summary

Layers cosine-similarity dedup on top of the existing text-equality cross-run dedup in `writeReflectionMemories`. Two new opt-in settings:

- `reflectionSemanticDedupEnabled` (boolean, default `false`)
- `reflectionSemanticDedupThreshold` (number, default `0.88`)

When enabled, each candidate reflection note is embedded and compared against recent reflection memories' stored embeddings; notes above the threshold are skipped.

## Motivation

The existing cross-run dedup catches reflections only when the LLM produces literally-identical normalized text. In practice the classifier rederives the same insight in different words across runs (\"Always verify before acting\" vs \"Confirm state first\"); text-equality misses these. In our deployment 95%+ of memory rows are routine `reflection/*` and the long tail is dominated by these near-duplicates.

Embedding-based dedup catches them. We already have `nomic-embed-text` on Ollama doing semantic retrieval for everything else — this just extends it to the reflection-write path.

## How it works

In `writeReflectionMemories`, after the existing text-equality cross-run loop, if `reflectionSemanticDedupEnabled`:

1. Load recent reflection memories' embeddings via the new `memoryDb.recentReflectionEmbeddings(agentId, sinceMs, limit)` method (reuses the same 7-day cutoff as text dedup).
2. For each candidate note, call `getEmbedding(note)` and check cosine similarity against the loaded embeddings.
3. If any exceeds the threshold, add the note's normalized form to a `semanticSkip` set checked in the write loop.

Graceful fallbacks:
- Embedder not configured → `getEmbedding` returns `null` → no semantic dedup, text dedup still runs.
- Recent memories have no stored embeddings → semantic dedup no-ops for that run.
- Any thrown error → caught and ignored; the write proceeds.

`writeReflectionMemories` becomes `async` to accommodate the embedder calls. The sole caller (`executeSupervisorAutoActions`) is already an async function, so the change is contained.

## Why opt-in

Each candidate note costs one embedder call (~10-20 ms with local `nomic-embed-text`, more for remote providers). For deployments running local Ollama already, the cost is negligible. For OpenAI embedding users it adds tokens. Default `false` leaves behavior unchanged.

## Files

- `src/types/app-settings.ts` — 2 new optional fields
- `src/lib/server/memory/memory-db.ts` — `recentReflectionEmbeddings` method
- `src/lib/server/autonomy/supervisor-reflection.ts` — semantic dedup pass; function now async

## Test plan

- [x] Reviewed by inspection.
- [ ] Operator verification: with `nomic-embed-text` already configured, set `reflectionSemanticDedupEnabled=true`, run two similar reflection-producing sessions back-to-back, confirm the second produces fewer `reflection/*` memory rows than baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)