### PR TITLE
fix: credential-env reads cred.encryptedKey (not cred.encrypted)

### DIFF
--- a/src/lib/server/session-tools/credential-env.ts
+++ b/src/lib/server/session-tools/credential-env.ts
@@ -36,7 +36,7 @@ export function buildCredentialEnv(credentialIds: string[]): CredentialEnv {
   const env: Record<string, string> = {}
   const secrets: string[] = []
 
-  const allCredentials = loadCredentials() as Record<string, Credential & { encrypted?: string }>
+  const allCredentials = loadCredentials() as Record<string, Credential & { encryptedKey?: string }>
 
   for (const credId of credentialIds) {
     const cred = allCredentials[credId]
@@ -45,8 +45,12 @@ export function buildCredentialEnv(credentialIds: string[]): CredentialEnv {
       continue
     }
 
-    // Decrypt the stored key
-    const encrypted = cred.encrypted
+    // Decrypt the stored key — credentials persist the ciphertext under
+    // `encryptedKey` (see createCredentialRecord in storage.ts; matching
+    // reads in connector-lifecycle, chatroom-helpers, daemon-state, etc.).
+    // Previously this file read `cred.encrypted`, which is never set, so
+    // credential injection silently no-op'd for every execute tool call.
+    const encrypted = cred.encryptedKey
     if (!encrypted || typeof encrypted !== 'string') {
       log.warn(TAG, `Credential has no encrypted value: ${credId}`)
       continue


### PR DESCRIPTION
## Summary

Field-name mismatch in \`buildCredentialEnv\`. It reads \`cred.encrypted\` per-credential, but \`createCredentialRecord\` persists the ciphertext under \`cred.encryptedKey\`. Every call falls into the \`Credential has no encrypted value\` warn branch and returns an empty env map.

Result: every agent that uses \`executeConfig.credentials\` to inject API tokens has been getting an **empty env**. The execute tool's credential injection is a silent no-op today.

## How I found it

Configured a fine-grained GitHub PAT as a credential on a worker agent, expecting \`gh\` inside its shell to authenticate via \`\$GITHUB_TOKEN\`:

\`\`\`
echo "GITHUB_TOKEN=\${#GITHUB_TOKEN}chars"
# → GITHUB_TOKEN=0chars
\`\`\`

\`gh\` then fell back to the host's keychain auth (much broader scope than the fine-grained PAT we tried to scope it to).

## Why this is the fix

Every other read site in the codebase already uses \`cred.encryptedKey\`:

\`\`\`
$ grep -rn 'cred.encryptedKey\\|cred\\.encrypted' src/ | grep -v .test.
src/lib/server/session-tools/credential-env.ts:  cred.encrypted     ← only consumer of the wrong field
src/app/api/setup/check-provider/route.ts:        cred.encryptedKey
src/lib/server/connectors/connector-lifecycle.ts: cred.encryptedKey
src/lib/server/chatrooms/chatroom-helpers.ts:     cred.encryptedKey
src/lib/server/runtime/daemon-state/core.ts:      cred.encryptedKey
\`\`\`

## Verified

After the patch (applied locally to the running build):

\`\`\`
echo "GITHUB_TOKEN=\${#GITHUB_TOKEN}chars; first8=\${GITHUB_TOKEN:0:8}"
# → GITHUB_TOKEN=93chars; first8=github_p
gh auth status
# → ✓ Logged in to github.com account siglimumuni (GITHUB_TOKEN)
\`\`\`

## Files

- \`src/lib/server/session-tools/credential-env.ts\` — one-character field rename + a comment explaining the convention.

## Test plan

- [x] Reviewed by inspection — single-line behavioral change.
- [x] Applied locally; runtime verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)