### PR TITLE
feat: AgentCreateSchema accepts workspace / filesystemScope / fileAccessPolicy

### DIFF
--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -140,6 +140,18 @@ export const AgentCreateSchema = z.object({
   projectId: z.string().optional(),
   avatarSeed: z.string().optional(),
   avatarUrl: z.string().nullable().optional().default(null),
+  /** Per-agent working directory. Used as the cwd for execute tool calls and
+   *  as the root for workspace-scoped file operations. */
+  workspace: z.string().nullable().optional().default(null),
+  /** When 'workspace', the structured file tool's reads/writes are confined to
+   *  the agent's workspace directory; 'machine' allows the whole host. */
+  filesystemScope: z.enum(['workspace', 'machine']).nullable().optional().default(null),
+  /** Per-agent filesystem allow/block lists enforced by the file tool. Globs
+   *  are matched against fully-resolved absolute paths. */
+  fileAccessPolicy: z.object({
+    allowedPaths: z.array(z.string()).optional(),
+    blockedPaths: z.array(z.string()).optional(),
+  }).nullable().optional().default(null),
   sandboxConfig: AgentSandboxConfigSchema,
   executeConfig: AgentExecuteConfigSchema,
   autoRecovery: z.boolean().optional().default(false),


### PR DESCRIPTION
## Summary

Three fields defined on the \`Agent\` type and consumed at runtime — \`workspace\`, \`filesystemScope\`, \`fileAccessPolicy\` — are missing from the Zod \`AgentCreateSchema\`. \`AgentUpdateSchema\` derives from it via \`.partial()\`, so PUT /api/agents/:id silently drops these fields. The runtime behaviors they control (workspace-scoped file ops, fileAccessPolicy enforcement) are therefore unreachable via the public API.

## How I found it

Tried to lock a worker agent down to a dedicated workspace via the API:

\`\`\`
PUT /api/agents/<id>
{
  \"workspace\": \"/Users/foo/agent-workspaces/hugo\",
  \"filesystemScope\": \"workspace\",
  \"fileAccessPolicy\": { \"blockedPaths\": [\"/Users/foo/.ssh/**\", ...] }
}
\`\`\`

Endpoint returned 200 with the agent record. But:

\`\`\`
GET /api/agents/<id>
→ workspace: null, filesystemScope: null, fileAccessPolicy: null
\`\`\`

Confirmed in the route handler ([app/api/agents/\\[id\\]/route.ts:20-29](https://github.com/swarmclawai/swarmclaw/blob/main/src/app/api/agents/%5Bid%5D/route.ts#L20-L29)): \`AgentUpdateSchema.safeParse(raw)\` strips unknown keys, then the post-parse filter restricts the body to keys present in \`parsed.data\` — and the missing schema entries mean those keys are absent from \`parsed.data\` entirely.

End result: the only way to set these fields is to write directly to the \`agents\` table.

## Fix

Add the three fields to \`AgentCreateSchema\` matching the types in \`src/types/agent.ts\`:

- \`workspace: string | null\`
- \`filesystemScope: 'workspace' | 'machine' | null\`
- \`fileAccessPolicy: { allowedPaths?: string[], blockedPaths?: string[] } | null\`

No runtime behavior change — just unblocks these fields round-tripping through the API.

## Files

- \`src/lib/validation/schemas.ts\` — 12 lines

## Test plan

- [x] Reviewed by inspection — schema-only change.
- [x] Applied locally; PUT now persists all three fields, GET returns them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)