### PR TITLE
fix: persist CREDENTIAL_SECRET in DATA_DIR to survive npm-global upgrades

### DIFF
--- a/src/lib/server/storage-auth.ts
+++ b/src/lib/server/storage-auth.ts
@@ -11,6 +11,13 @@ const TAG = 'storage-auth'
 // because DATA_DIR is volume-mounted, unlike process.cwd()/.env.local.
 const GENERATED_ENV_PATH = path.join(DATA_DIR, '.env.generated')
 
+// Dedicated single-purpose file for the credential-encryption secret. Lives in
+// DATA_DIR so it survives both Docker volume mounts AND npm-global upgrades
+// (the latter changes process.cwd() per version, which made .env.local-only
+// persistence regenerate the secret every upgrade and orphan every credential
+// encrypted under the old value).
+const CREDENTIAL_SECRET_FILE = path.join(DATA_DIR, 'credential-secret')
+
 // --- .env loading ---
 function loadEnvFile(filePath: string): void {
   if (!fs.existsSync(filePath)) return
@@ -59,12 +66,69 @@ function persistEnvKey(key: string, value: string): void {
   }
 }
 
-// Auto-generate CREDENTIAL_SECRET if missing
-if (!IS_BUILD_BOOTSTRAP && !process.env.CREDENTIAL_SECRET) {
-  const secret = crypto.randomBytes(32).toString('hex')
-  process.env.CREDENTIAL_SECRET = secret
-  persistEnvKey('CREDENTIAL_SECRET', secret)
-  log.info(TAG, 'Generated CREDENTIAL_SECRET')
+/** Read CREDENTIAL_SECRET from the dedicated file in DATA_DIR.
+ *  Returns the trimmed contents, or empty string if absent / unreadable. */
+function readCredentialSecretFile(): string {
+  try {
+    if (!fs.existsSync(CREDENTIAL_SECRET_FILE)) return ''
+    return fs.readFileSync(CREDENTIAL_SECRET_FILE, 'utf-8').trim()
+  } catch (err) {
+    log.warn(TAG, `Could not read CREDENTIAL_SECRET from ${CREDENTIAL_SECRET_FILE}`, {
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return ''
+  }
+}
+
+/** Write CREDENTIAL_SECRET to the dedicated file with restrictive permissions. */
+function writeCredentialSecretFile(secret: string): boolean {
+  try {
+    fs.mkdirSync(path.dirname(CREDENTIAL_SECRET_FILE), { recursive: true })
+    fs.writeFileSync(CREDENTIAL_SECRET_FILE, secret, { encoding: 'utf-8', mode: 0o600 })
+    return true
+  } catch (err) {
+    log.warn(TAG, `Could not persist CREDENTIAL_SECRET to ${CREDENTIAL_SECRET_FILE}`, {
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return false
+  }
+}
+
+// Resolve CREDENTIAL_SECRET in this precedence order:
+//   1. process.env (already set externally, e.g. by orchestrator)
+//   2. DATA_DIR/credential-secret (the stable home — survives upgrades)
+//   3. .env files (legacy — values loaded into process.env by loadEnv() above)
+//   4. Generate new secret + persist to DATA_DIR/credential-secret
+//
+// Step 2 is the key change: previously the secret only lived in a per-version
+// .env.local (cwd changes on npm-global upgrade), so each upgrade
+// silently regenerated it and orphaned every encrypted credential.
+if (!IS_BUILD_BOOTSTRAP) {
+  // If a previous version wrote the secret to .env.local / .env.generated,
+  // loadEnv() above already placed it on process.env. Treat that as the
+  // authoritative value AND migrate it into the dedicated file so future
+  // upgrades read from there.
+  const envSecret = process.env.CREDENTIAL_SECRET?.trim() || ''
+  const fileSecret = readCredentialSecretFile()
+  if (envSecret && !fileSecret) {
+    if (writeCredentialSecretFile(envSecret)) {
+      log.info(TAG, `Migrated CREDENTIAL_SECRET from .env to ${CREDENTIAL_SECRET_FILE}`)
+    }
+  } else if (fileSecret && !envSecret) {
+    process.env.CREDENTIAL_SECRET = fileSecret
+  } else if (fileSecret && envSecret && fileSecret !== envSecret) {
+    // Both are set and disagree — trust the dedicated file (the stable home)
+    // and warn loudly. This usually means a fresh .env.local got generated
+    // during install and contains a stale value; the file is authoritative.
+    log.warn(TAG, `CREDENTIAL_SECRET mismatch between env and ${CREDENTIAL_SECRET_FILE}; using the file value (older credentials encrypted under that secret are recoverable, the env value would orphan them).`)
+    process.env.CREDENTIAL_SECRET = fileSecret
+  } else if (!envSecret && !fileSecret) {
+    // First-ever launch on this DATA_DIR. Generate.
+    const secret = crypto.randomBytes(32).toString('hex')
+    process.env.CREDENTIAL_SECRET = secret
+    writeCredentialSecretFile(secret)
+    log.info(TAG, `Generated CREDENTIAL_SECRET and persisted to ${CREDENTIAL_SECRET_FILE}`)
+  }
 }
 
 // Auto-generate ACCESS_KEY if missing (used for simple auth)


### PR DESCRIPTION
## Summary

\`CREDENTIAL_SECRET\` is persisted via \`appendEnvKeyIfMissing\` to \`.env.local\` inside \`process.cwd()\`. For npm-global installs, \`cwd\` is the per-version build directory (\`~/.swarmclaw/builds/package-<ver>/.next/standalone/\`). Each upgrade lands in a fresh build dir with a fresh empty \`.env.local\`; the auto-generate branch in \`storage-auth.ts\` fires (since the env var is unset in the new cwd); a brand-new 32-byte secret gets written.

**Net effect: every npm-global upgrade silently regenerates \`CREDENTIAL_SECRET\`.** Every credential encrypted under the prior secret becomes unreadable. The decrypt failure goes into \`try/catch\` blocks throughout the codebase and produces empty values — Slack connectors come up with \`\"No bot token configured\"\`, agent execute shells get empty env vars, every provider key in Settings → Providers needs to be re-entered.

## How I hit this

Upgraded a running install from v1.9.31 → v1.9.32 (\`npm install -g @swarmclawai/swarmclaw@1.9.32\`). After \`launchctl kickstart\` brought the service back:

- All 8 Slack connectors reported \`lastError = \"No bot token configured\"\`. Cycling them didn't help.
- \`gh\` inside an agent's execute shell reported empty \`\$GITHUB_TOKEN\` despite the credential being properly configured on the agent.
- The credential records in storage are intact — \`encryptedKey\` field is unchanged. The decrypt just silently fails.

\`diff\`'d the two \`.env.local\`s:

\`\`\`
v1.9.31: CREDENTIAL_SECRET=ac7e4c83…
v1.9.32: CREDENTIAL_SECRET=5529ec0f…   ← regenerated during the upgrade
\`\`\`

Restoring the old secret into v1.9.32's \`.env.local\` and restarting unblocked everything. But that workaround breaks on every future upgrade.

## Fix

Store the secret in a dedicated file in \`DATA_DIR\` (\`<DATA_DIR>/credential-secret\`), which is stable across npm-global upgrades and already volume-mounted in Docker. Resolution precedence in \`storage-auth.ts\`:

1. \`process.env.CREDENTIAL_SECRET\` (already set externally, e.g. by orchestrator)
2. **\`<DATA_DIR>/credential-secret\`** — the new stable home
3. \`.env\` files (legacy — values from \`loadEnv()\`)
4. Generate + persist to \`<DATA_DIR>/credential-secret\`

Migration is automatic: on first launch after this fix lands, an existing secret found via \`.env.local\` gets copied into the dedicated file. Future upgrades read from the file directly. File permissions: \`0o600\`.

If both the env-loaded value AND the file are set and disagree, the **file wins** (with a \`log.warn\`) — that case typically means a stale \`.env.local\` was regenerated during install and would orphan working credentials if trusted.

## Files

- \`src/lib/server/storage-auth.ts\` — 70 lines

## Test plan

- [x] Reviewed by inspection.
- [x] Applied locally as a workaround (manual secret restoration) to confirm credential decryption recovers.
- [ ] Operator verification: after PR lands, upgrade across a minor version with this fix applied — confirm \`<DATA_DIR>/credential-secret\` exists with restrictive perms, secret survives, all credentials still decrypt.

## Notes

\`ACCESS_KEY\` has the same per-version-cwd persistence problem (and gets regenerated on every upgrade too) but isn't as catastrophic — it just forces an auth re-login. Left for a follow-up if there's interest in symmetric treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)