### PR TITLE
feat: add TokenMix as a built-in OpenAI-compatible provider

### DIFF
--- a/src/lib/providers/index.ts
+++ b/src/lib/providers/index.ts
@@ -128,6 +128,29 @@ export const PROVIDERS: Record<string, BuiltinProviderConfig> = {
       },
     },
   },
+  tokenmix: {
+    id: 'tokenmix',
+    name: 'TokenMix',
+    models: [
+      'claude-opus-4-6', 'claude-sonnet-4-6', 'claude-haiku-4-5',
+      'gpt-5.4', 'gpt-5.4-mini',
+      'gemini-2.5-pro', 'gemini-2.5-flash',
+      'deepseek-chat', 'deepseek-reasoner',
+      'qwen-max',
+    ],
+    requiresApiKey: true,
+    requiresEndpoint: false,
+    defaultEndpoint: 'https://api.tokenmix.ai/v1',
+    handler: {
+      streamChat: (opts) => {
+        const patchedSession = {
+          ...opts.session,
+          apiEndpoint: opts.session.apiEndpoint || 'https://api.tokenmix.ai/v1',
+        }
+        return streamOpenAiChat({ ...opts, session: patchedSession })
+      },
+    },
+  },
   anthropic: {
     id: 'anthropic',
     name: 'Anthropic',


### PR DESCRIPTION
## Summary

Adds **TokenMix** as a built-in provider in src/lib/providers/index.ts, placed after OpenRouter since both are OpenAI-compatible API aggregators.

### Change

New 	okenmix provider block with 10 curated models:

`	ypescript
tokenmix: {
  id: 'tokenmix',
  name: 'TokenMix',
  models: [
    'claude-opus-4-6', 'claude-sonnet-4-6', 'claude-haiku-4-5',
    'gpt-5.4', 'gpt-5.4-mini',
    'gemini-2.5-pro', 'gemini-2.5-flash',
    'deepseek-chat', 'deepseek-reasoner',
    'qwen-max',
  ],
  requiresApiKey: true,
  requiresEndpoint: false,
  defaultEndpoint: 'https://api.tokenmix.ai/v1',
  handler: { streamChat: streamOpenAiChat },
},
`

### Why TokenMix?

TokenMix is an OpenAI-compatible API aggregator — same category and integration pattern as OpenRouter. It provides **171 models from 14 providers** through a single endpoint with pay-as-you-go pricing.

| | TokenMix | OpenRouter |
|--|---------|-----------|
| Endpoint | pi.tokenmix.ai/v1 | openrouter.ai/api/v1 |
| Protocol | OpenAI-compatible | OpenAI-compatible |
| Models | 171 | 300+ |
| Auth | Bearer API key | Bearer API key |

Zero new dependencies — reuses the existing streamOpenAiChat handler.