### PR TITLE
fix: publish zip-only unsigned macOS desktop artifacts

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -135,8 +135,10 @@ jobs:
 
           if [ "$has_certificate" = true ] && { [ "$has_apple_id_notary" = true ] || [ "$has_api_key_notary" = true ]; }; then
             echo "Developer ID signing and notarization inputs are configured."
+            echo "SWARMCLAW_ELECTRON_MAC_TARGETS=dmg,zip" >> "$GITHUB_ENV"
           else
-            echo "Developer ID signing and notarization inputs are incomplete; macOS artifacts will remain ad-hoc signed."
+            echo "Developer ID signing and notarization inputs are incomplete; publishing zip-only macOS artifacts to avoid damaged unsigned DMGs."
+            echo "SWARMCLAW_ELECTRON_MAC_TARGETS=zip" >> "$GITHUB_ENV"
           fi
 
       - name: Export macOS signing environment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,7 @@ jobs:
           echo "- \`docker pull ${{ steps.image.outputs.name }}:${{ github.ref_name }}\`" >> "$BODY_PATH"
           echo "- \`docker pull ${{ steps.image.outputs.name }}:latest\`" >> "$BODY_PATH"
           echo "## macOS desktop" >> "$BODY_PATH"
-          echo "- macOS builds are notarized when Developer ID and Apple notarization secrets are configured for the desktop release workflow. If a build is still ad-hoc signed and Finder says SwarmClaw is damaged, run \`xattr -dr com.apple.quarantine /Applications/SwarmClaw.app\` after installing, then open it again." >> "$BODY_PATH"
+          echo "- macOS builds publish both .dmg and .zip when Developer ID signing + notarization are configured. Until then, the desktop workflow publishes zip-only macOS artifacts to avoid the damaged unsigned DMG path. If Finder still reports a quarantined app, run \`xattr -dr com.apple.quarantine /Applications/SwarmClaw.app\` after installing, then open it again." >> "$BODY_PATH"
           echo "path=$BODY_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Available for macOS (Apple Silicon & Intel), Windows, and Linux (AppImage + .deb
 The release workflow supports Developer ID signing and notarization when Apple
 credentials are configured. If a macOS build is still ad-hoc signed, first
 launch may need one manual approval:
-- **macOS:** right-click the app in Finder → **Open** → **Open** to bypass Gatekeeper. If macOS instead reports *"SwarmClaw is damaged and can't be opened"* (common when the dmg was quarantined by Safari), strip the quarantine attribute and relaunch:
+- **macOS:** signed/notarized releases publish both `.dmg` and `.zip`; unsigned fallback releases publish `.zip` only to avoid the damaged unsigned DMG path. Right-click the app in Finder → **Open** → **Open** to bypass Gatekeeper. If macOS instead reports *"SwarmClaw is damaged and can't be opened"* (common when a downloaded app was quarantined by Safari), strip the quarantine attribute and relaunch:
   ```bash
   xattr -dr com.apple.quarantine /Applications/SwarmClaw.app
   ```

--- a/scripts/build-electron.mjs
+++ b/scripts/build-electron.mjs
@@ -19,6 +19,15 @@ const platformFlag = args.has('--mac') ? '--mac'
   : args.has('--win') ? '--win'
   : args.has('--linux') ? '--linux'
   : null
+const targetArg = process.argv.slice(2).find((arg) => arg.startsWith('--targets='))
+const explicitTargets = targetArg
+  ? targetArg.slice('--targets='.length).split(',').map((value) => value.trim()).filter(Boolean)
+  : []
+const envTargets = (process.env.SWARMCLAW_ELECTRON_MAC_TARGETS || '')
+  .split(',')
+  .map((value) => value.trim())
+  .filter(Boolean)
+const macTargets = explicitTargets.length > 0 ? explicitTargets : envTargets
 
 function run(cmd, cmdArgs, env = {}) {
   const status = runWithStatus(cmd, cmdArgs, env)
@@ -86,6 +95,7 @@ if (fs.existsSync(publicDir)) {
 console.log('[build-electron] running electron-builder…')
 const builderArgs = []
 if (platformFlag) builderArgs.push(platformFlag)
+if (platformFlag === '--mac' && macTargets.length > 0) builderArgs.push(...macTargets)
 if (publishAlways) {
   builderArgs.push('--publish', 'always')
 } else {

--- a/scripts/electron-signing-config.test.mjs
+++ b/scripts/electron-signing-config.test.mjs
@@ -42,5 +42,18 @@ describe('macOS desktop signing configuration', () => {
 
     assert.equal(desktopWorkflow.includes("CSC_IDENTITY_AUTO_DISCOVERY: 'false'"), false)
     assert.equal(desktopWorkflow.includes('CSC_IDENTITY_AUTO_DISCOVERY: "false"'), false)
+
+    assert.ok(
+      desktopWorkflow.includes('echo "SWARMCLAW_ELECTRON_MAC_TARGETS=dmg,zip" >> "$GITHUB_ENV"'),
+      'signed macOS desktop releases should keep publishing dmg + zip artifacts',
+    )
+    assert.ok(
+      desktopWorkflow.includes('echo "SWARMCLAW_ELECTRON_MAC_TARGETS=zip" >> "$GITHUB_ENV"'),
+      'unsigned macOS desktop releases should fall back to zip-only artifacts',
+    )
+    assert.ok(
+      fs.readFileSync(path.join(repoRoot, 'scripts', 'build-electron.mjs'), 'utf8').includes('SWARMCLAW_ELECTRON_MAC_TARGETS'),
+      'electron build script should honor mac target overrides from the workflow',
+    )
   })
 })


### PR DESCRIPTION
## Summary
Fixes #46 by avoiding the unsigned macOS DMG path that triggers the “SwarmClaw is damaged” install failure.

## Changes
- publish `zip`-only macOS desktop artifacts when Developer ID / notarization secrets are missing
- keep `dmg` + `zip` for properly signed/notarized macOS releases
- document the new fallback in the release body and README
- add a regression check that the workflow exports the right macOS targets and the build script consumes them

## Verification
- `node --test scripts/electron-signing-config.test.mjs` ✅
- `npm run test:cli` ⚠️ fails in pre-existing CLI tests unrelated to this change (`src/cli/binary.test.js` missing `commander` / stale tsx expectations)
