### PR TITLE
Resolve OpenRouter context windows from model metadata

### DIFF
--- a/src/app/api/chats/[id]/context-status/route.ts
+++ b/src/app/api/chats/[id]/context-status/route.ts
@@ -3,6 +3,7 @@ import { getSession } from '@/lib/server/sessions/session-repository'
 import { getMessages } from '@/lib/server/messages/message-repository'
 import { getContextStatus } from '@/lib/server/context-manager'
 import { notFound } from '@/lib/server/collection-helpers'
+import { ensureOpenRouterModelContextCache } from '@/lib/server/openrouter-model-context'
 
 const SYSTEM_PROMPT_TOKEN_ESTIMATE = 2000
 
@@ -11,6 +12,7 @@ export async function GET(_req: Request, { params }: { params: Promise<{ id: str
   const session = getSession(id)
   if (!session) return notFound()
   const messages = getMessages(id)
+  await ensureOpenRouterModelContextCache(session.provider as string)
   const status = getContextStatus(
     messages,
     SYSTEM_PROMPT_TOKEN_ESTIMATE,

--- a/src/app/api/chats/context-status-route.test.ts
+++ b/src/app/api/chats/context-status-route.test.ts
@@ -66,3 +66,62 @@ test('GET /api/chats/[id]/context-status returns token usage summary', () => {
   assert.ok(['ok', 'warning', 'critical'].includes(output.strategy))
   assert.equal(output.missingStatus, 404)
 })
+
+test('GET /api/chats/[id]/context-status uses OpenRouter model metadata context window', () => {
+  const output = runWithTempDataDir<{
+    status: number
+    contextWindow: number
+  }>(`
+    const fs = await import('node:fs')
+    const path = await import('node:path')
+    const cachePath = path.join(process.env.DATA_DIR, 'openrouter-model-context.json')
+    fs.writeFileSync(cachePath, JSON.stringify({
+      loadedAt: Date.now(),
+      models: { 'minimax/minimax-m3': 524288 },
+    }))
+
+    globalThis.fetch = async () => {
+      throw new Error('route should use seeded OpenRouter model metadata cache')
+    }
+
+    const storageMod = await import('./src/lib/server/storage')
+    const repoMod = await import('@/lib/server/messages/message-repository')
+    const routeMod = await import('./src/app/api/chats/[id]/context-status/route')
+    const storage = storageMod.default || storageMod
+    const repo = repoMod.default || repoMod
+    const route = routeMod.default || routeMod
+
+    const now = Date.now()
+    storage.saveSessions({
+      sess_ctx_openrouter: {
+        id: 'sess_ctx_openrouter',
+        name: 'OpenRouter context status test',
+        cwd: process.env.WORKSPACE_DIR,
+        user: 'tester',
+        provider: 'openrouter',
+        model: 'minimax/minimax-m3',
+        claudeSessionId: null,
+        messages: [],
+        createdAt: now,
+        lastActiveAt: now,
+      },
+    })
+
+    repo.appendMessage('sess_ctx_openrouter', { role: 'user', text: 'hello world', time: now })
+
+    const response = await route.GET(
+      new Request('http://local/api/chats/sess_ctx_openrouter/context-status'),
+      { params: Promise.resolve({ id: 'sess_ctx_openrouter' }) },
+    )
+    const payload = await response.json()
+
+    console.log(JSON.stringify({
+      status: response.status,
+      contextWindow: payload.contextWindow,
+    }))
+  `, { prefix: 'swarmclaw-context-status-route-' })
+
+  assert.equal(output.status, 200)
+  assert.equal(output.contextWindow, 524_288)
+  assert.notEqual(output.contextWindow, 8_192)
+})

--- a/src/lib/server/context-manager.ts
+++ b/src/lib/server/context-manager.ts
@@ -2,6 +2,7 @@ import type { Message, Session } from '@/types'
 import { getMemoryDb } from '@/lib/server/memory/memory-db'
 import { extractFactsFromMessages, ensureRunContext, pruneRunContext } from '@/lib/server/run-context'
 import { getSession, saveSession } from '@/lib/server/sessions/session-repository'
+import { getCachedOpenRouterContextWindow } from '@/lib/server/openrouter-model-context'
 
 import { repairTranscriptConsistency } from './transcript-repair'
 
@@ -97,6 +98,9 @@ const PROVIDER_DEFAULT_WINDOWS: Record<string, number> = {
 
 /** Get context window size for a model, falling back to provider default */
 export function getContextWindowSize(provider: string, model: string): number {
+  const openRouterContext = getCachedOpenRouterContextWindow(provider, model)
+  if (openRouterContext) return openRouterContext
+
   return PROVIDER_CONTEXT_WINDOWS[model]
     || PROVIDER_DEFAULT_WINDOWS[provider]
     || 8_192

--- a/src/lib/server/openrouter-model-context.test.ts
+++ b/src/lib/server/openrouter-model-context.test.ts
@@ -1,0 +1,205 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { runWithTempDataDir } from '@/lib/server/test-utils/run-with-temp-data-dir'
+
+interface OpenRouterContextResult {
+  contextWindow: number | null
+  fetchCalls?: number
+}
+
+function runOpenRouterContextScript(script: string): OpenRouterContextResult {
+  return runWithTempDataDir<OpenRouterContextResult>(script, {
+    prefix: 'swarmclaw-openrouter-context-',
+  })
+}
+
+test('exact OpenRouter model ID returns cached context length', () => {
+  const output = runOpenRouterContextScript(`
+    const fs = await import('node:fs')
+    const path = await import('node:path')
+    const cachePath = path.join(process.env.DATA_DIR, 'openrouter-model-context.json')
+    fs.writeFileSync(cachePath, JSON.stringify({
+      loadedAt: Date.now(),
+      models: { 'minimax/minimax-m3': 524288 },
+    }))
+
+    const modImport = await import('./src/lib/server/openrouter-model-context')
+    const mod = modImport.default || modImport
+    globalThis.fetch = async () => {
+      throw new Error('fetch should not run when cache is fresh')
+    }
+
+    await mod.ensureOpenRouterModelContextCache('openrouter')
+    console.log(JSON.stringify({
+      contextWindow: mod.getCachedOpenRouterContextWindow('openrouter', 'minimax/minimax-m3'),
+    }))
+  `)
+
+  assert.equal(output.contextWindow, 524_288)
+})
+
+test('top_provider.context_length is preferred over context_length', () => {
+  const output = runOpenRouterContextScript(`
+    const modImport = await import('./src/lib/server/openrouter-model-context')
+    const mod = modImport.default || modImport
+    globalThis.fetch = async () => new Response(JSON.stringify({
+      data: [{
+        id: 'provider/model-a',
+        context_length: 8192,
+        top_provider: { context_length: 131072 },
+      }],
+    }), { status: 200 })
+
+    await mod.ensureOpenRouterModelContextCache('openrouter')
+    console.log(JSON.stringify({
+      contextWindow: mod.getCachedOpenRouterContextWindow('openrouter', 'provider/model-a'),
+    }))
+  `)
+
+  assert.equal(output.contextWindow, 131_072)
+})
+
+test('unique suffix match works for unprefixed model IDs', () => {
+  const output = runOpenRouterContextScript(`
+    const modImport = await import('./src/lib/server/openrouter-model-context')
+    const mod = modImport.default || modImport
+    globalThis.fetch = async () => new Response(JSON.stringify({
+      data: [{ id: 'google/gemini-2.5-pro', context_length: 1048576 }],
+    }), { status: 200 })
+
+    await mod.ensureOpenRouterModelContextCache('openrouter')
+    console.log(JSON.stringify({
+      contextWindow: mod.getCachedOpenRouterContextWindow('openrouter', 'gemini-2.5-pro'),
+    }))
+  `)
+
+  assert.equal(output.contextWindow, 1_048_576)
+})
+
+test('ambiguous suffix match returns null', () => {
+  const output = runOpenRouterContextScript(`
+    const modImport = await import('./src/lib/server/openrouter-model-context')
+    const mod = modImport.default || modImport
+    globalThis.fetch = async () => new Response(JSON.stringify({
+      data: [
+        { id: 'provider-a/shared-model', context_length: 32000 },
+        { id: 'provider-b/shared-model', context_length: 64000 },
+      ],
+    }), { status: 200 })
+
+    await mod.ensureOpenRouterModelContextCache('openrouter')
+    console.log(JSON.stringify({
+      contextWindow: mod.getCachedOpenRouterContextWindow('openrouter', 'shared-model'),
+    }))
+  `)
+
+  assert.equal(output.contextWindow, null)
+})
+
+test('non-OpenRouter provider returns null', () => {
+  const output = runOpenRouterContextScript(`
+    const modImport = await import('./src/lib/server/openrouter-model-context')
+    const mod = modImport.default || modImport
+    console.log(JSON.stringify({
+      contextWindow: mod.getCachedOpenRouterContextWindow('openai', 'minimax/minimax-m3'),
+    }))
+  `)
+
+  assert.equal(output.contextWindow, null)
+})
+
+test('failed fetch does not throw', () => {
+  const output = runOpenRouterContextScript(`
+    const modImport = await import('./src/lib/server/openrouter-model-context')
+    const mod = modImport.default || modImport
+    let fetchCalls = 0
+    globalThis.fetch = async () => {
+      fetchCalls += 1
+      throw new Error('network down')
+    }
+
+    await mod.ensureOpenRouterModelContextCache('openrouter')
+    console.log(JSON.stringify({
+      contextWindow: mod.getCachedOpenRouterContextWindow('openrouter', 'minimax/minimax-m3'),
+      fetchCalls,
+    }))
+  `)
+
+  assert.equal(output.contextWindow, null)
+  assert.equal(output.fetchCalls, 1)
+})
+
+test('timed out fetch does not throw', () => {
+  const output = runOpenRouterContextScript(`
+    const modImport = await import('./src/lib/server/openrouter-model-context')
+    const mod = modImport.default || modImport
+    let fetchCalls = 0
+    globalThis.fetch = async (_input, init) => {
+      fetchCalls += 1
+      await new Promise((_resolve, reject) => {
+        init.signal.addEventListener('abort', () => reject(init.signal.reason), { once: true })
+      })
+    }
+
+    await mod.ensureOpenRouterModelContextCache('openrouter')
+    console.log(JSON.stringify({
+      contextWindow: mod.getCachedOpenRouterContextWindow('openrouter', 'minimax/minimax-m3'),
+      fetchCalls,
+    }))
+  `)
+
+  assert.equal(output.contextWindow, null)
+  assert.equal(output.fetchCalls, 1)
+})
+
+test('stale cache is ignored', () => {
+  const output = runOpenRouterContextScript(`
+    const fs = await import('node:fs')
+    const path = await import('node:path')
+    const cachePath = path.join(process.env.DATA_DIR, 'openrouter-model-context.json')
+    fs.writeFileSync(cachePath, JSON.stringify({
+      loadedAt: Date.now() - (25 * 60 * 60 * 1000),
+      models: { 'minimax/minimax-m3': 524288 },
+    }))
+
+    const modImport = await import('./src/lib/server/openrouter-model-context')
+    const mod = modImport.default || modImport
+    let fetchCalls = 0
+    globalThis.fetch = async () => {
+      fetchCalls += 1
+      throw new Error('network down')
+    }
+
+    await mod.ensureOpenRouterModelContextCache('openrouter')
+    console.log(JSON.stringify({
+      contextWindow: mod.getCachedOpenRouterContextWindow('openrouter', 'minimax/minimax-m3'),
+      fetchCalls,
+    }))
+  `)
+
+  assert.equal(output.contextWindow, null)
+  assert.equal(output.fetchCalls, 1)
+})
+
+test('cache write failure does not throw', () => {
+  const output = runOpenRouterContextScript(`
+    const fs = await import('node:fs')
+    const path = await import('node:path')
+    const cachePath = path.join(process.env.DATA_DIR, 'openrouter-model-context.json')
+    fs.mkdirSync(cachePath)
+
+    const modImport = await import('./src/lib/server/openrouter-model-context')
+    const mod = modImport.default || modImport
+    globalThis.fetch = async () => new Response(JSON.stringify({
+      data: [{ id: 'provider/model-a', context_length: 65536 }],
+    }), { status: 200 })
+
+    await mod.ensureOpenRouterModelContextCache('openrouter')
+    console.log(JSON.stringify({
+      contextWindow: mod.getCachedOpenRouterContextWindow('openrouter', 'provider/model-a'),
+    }))
+  `)
+
+  assert.equal(output.contextWindow, 65_536)
+})

--- a/src/lib/server/openrouter-model-context.ts
+++ b/src/lib/server/openrouter-model-context.ts
@@ -1,0 +1,169 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+import { fetchWithTimeout } from '@/lib/fetch-timeout'
+import { DATA_DIR } from '@/lib/server/data-dir'
+
+interface OpenRouterModelEntry {
+  id?: string
+  context_length?: number
+  top_provider?: {
+    context_length?: number
+  }
+}
+
+interface OpenRouterModelsResponse {
+  data?: OpenRouterModelEntry[]
+}
+
+interface OpenRouterModelContextCache {
+  loadedAt: number
+  models: Record<string, number>
+}
+
+const OPENROUTER_MODELS_URL = 'https://openrouter.ai/api/v1/models'
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000
+const FETCH_TIMEOUT_MS = 2_000
+const CACHE_PATH = path.join(DATA_DIR, 'openrouter-model-context.json')
+
+let cache: OpenRouterModelContextCache | null = null
+let loading: Promise<void> | null = null
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function parseModelEntry(value: unknown): OpenRouterModelEntry | null {
+  if (!isRecord(value)) return null
+
+  const entry: OpenRouterModelEntry = {}
+  if (typeof value.id === 'string') entry.id = value.id
+  if (typeof value.context_length === 'number') entry.context_length = value.context_length
+
+  if (isRecord(value.top_provider)) {
+    const topProvider: OpenRouterModelEntry['top_provider'] = {}
+    if (typeof value.top_provider.context_length === 'number') {
+      topProvider.context_length = value.top_provider.context_length
+    }
+    entry.top_provider = topProvider
+  }
+
+  return entry
+}
+
+function parseModelsResponse(value: unknown): OpenRouterModelsResponse {
+  if (!isRecord(value) || !Array.isArray(value.data)) return {}
+  return {
+    data: value.data
+      .map(parseModelEntry)
+      .filter((entry): entry is OpenRouterModelEntry => entry !== null),
+  }
+}
+
+function parseCache(value: unknown): OpenRouterModelContextCache | null {
+  if (!isRecord(value) || typeof value.loadedAt !== 'number' || !isRecord(value.models)) {
+    return null
+  }
+
+  const models: Record<string, number> = {}
+  for (const [id, contextLength] of Object.entries(value.models)) {
+    if (typeof contextLength === 'number' && Number.isFinite(contextLength) && contextLength > 0) {
+      models[id] = contextLength
+    }
+  }
+
+  return { loadedAt: value.loadedAt, models }
+}
+
+function isFreshCache(value: OpenRouterModelContextCache | null): value is OpenRouterModelContextCache {
+  return value !== null
+    && Number.isFinite(value.loadedAt)
+    && Date.now() - value.loadedAt <= CACHE_TTL_MS
+}
+
+async function readCache(): Promise<OpenRouterModelContextCache | null> {
+  try {
+    const raw = await fs.readFile(CACHE_PATH, 'utf8')
+    const parsed = parseCache(JSON.parse(raw))
+    return isFreshCache(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+async function writeCache(nextCache: OpenRouterModelContextCache): Promise<void> {
+  try {
+    await fs.mkdir(DATA_DIR, { recursive: true })
+    await fs.writeFile(CACHE_PATH, JSON.stringify(nextCache), 'utf8')
+  } catch {
+    // Best-effort cache. Runtime behavior should not depend on disk writes.
+  }
+}
+
+function buildModelContextMap(response: OpenRouterModelsResponse): Record<string, number> {
+  const models: Record<string, number> = {}
+  for (const entry of response.data || []) {
+    if (!entry.id) continue
+    const contextLength = entry.top_provider?.context_length || entry.context_length
+    if (typeof contextLength === 'number' && Number.isFinite(contextLength) && contextLength > 0) {
+      models[entry.id] = contextLength
+    }
+  }
+  return models
+}
+
+async function fetchOpenRouterModels(): Promise<OpenRouterModelContextCache | null> {
+  try {
+    const response = await fetchWithTimeout(OPENROUTER_MODELS_URL, {}, FETCH_TIMEOUT_MS)
+    if (!response.ok) return null
+
+    const payload = parseModelsResponse(await response.json())
+    return {
+      loadedAt: Date.now(),
+      models: buildModelContextMap(payload),
+    }
+  } catch {
+    return null
+  }
+}
+
+async function loadOpenRouterModelContextCache(): Promise<void> {
+  const diskCache = await readCache()
+  if (diskCache) {
+    cache = diskCache
+    return
+  }
+
+  const fetchedCache = await fetchOpenRouterModels()
+  if (!fetchedCache) return
+
+  cache = fetchedCache
+  await writeCache(fetchedCache)
+}
+
+export function getCachedOpenRouterContextWindow(provider: string, model: string): number | null {
+  if (provider !== 'openrouter' || !isFreshCache(cache)) return null
+
+  const exactMatch = cache.models[model]
+  if (exactMatch) return exactMatch
+
+  if (model.includes('/')) return null
+
+  const suffixMatches = Object.entries(cache.models)
+    .filter(([id]) => id.endsWith(`/${model}`))
+    .map(([, contextLength]) => contextLength)
+
+  return suffixMatches.length === 1 ? suffixMatches[0] : null
+}
+
+export async function ensureOpenRouterModelContextCache(provider: string): Promise<void> {
+  if (provider !== 'openrouter' || isFreshCache(cache)) return
+
+  if (!loading) {
+    loading = loadOpenRouterModelContextCache().finally(() => {
+      loading = null
+    })
+  }
+
+  await loading
+}


### PR DESCRIPTION
OpenRouter stores routed model IDs with provider prefixes such as minimax/minimax-m3 and google/gemini-2.5-pro.

The context meter previously resolved context windows only from static local maps and then fell back to 8192. This caused OpenRouter models with larger real context windows to display as 8192.

This change adds a cached OpenRouter model context registry based on /api/v1/models and uses top_provider.context_length or context_length when available. The existing 8192 fallback remains unchanged when metadata is unavailable.